### PR TITLE
Use double quotes for author name fields

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'{{ cookiecutter.project_name }}'
-copyright = u'{{ cookiecutter.year }}, {{ cookiecutter.author_name }}'
+copyright = u"{{ cookiecutter.year }}, {{ cookiecutter.author_name }}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -187,7 +187,7 @@ latex_documents = [
     ('index',
      '{{ cookiecutter.repo_name }}.tex',
      u'{{ cookiecutter.project_name }} Documentation',
-     u'{{ cookiecutter.author_name }}', 'manual'),
+     u"{{ cookiecutter.author_name }}", 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -217,7 +217,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', '{{ cookiecutter.repo_name }}', u'{{ cookiecutter.project_name }} Documentation',
-     [u'{{ cookiecutter.author_name }}'], 1)
+     [u"{{ cookiecutter.author_name }}"], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -231,7 +231,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', '{{ cookiecutter.repo_name }}', u'{{ cookiecutter.project_name }} Documentation',
-     u'{{ cookiecutter.author_name }}', '{{ cookiecutter.project_name }}',
+     u"{{ cookiecutter.author_name }}", '{{ cookiecutter.project_name }}',
      '{{ cookiecutter.description }}', 'Miscellaneous'),
 ]
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -16,7 +16,7 @@ version = {{ cookiecutter.repo_name }}.__version__
 setup(
     name='{{ cookiecutter.project_name }}',
     version=version,
-    author='{{ cookiecutter.full_name }}',
+    author="{{ cookiecutter.full_name }}",
     author_email='{{ cookiecutter.email }}',
     packages=[
         '{{ cookiecutter.repo_name }}',


### PR DESCRIPTION
This is meant to handle errors caused when the author name
contains punctuation i.e apostrophes
This is causing some errors in that the apostrophes are closing some single quotes fields early
This addresses #177 