### PR TITLE
Change full_name to author_name in setup.py

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -36,6 +36,7 @@ Matt Warren / @mfwarren
 Martin Blech
 Andy Rose
 Andrew Mikhnevich / @zcho
+Kevin Ndung'u / @kevgathuku
 
 * Possesses commit rights
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -16,7 +16,7 @@ version = {{ cookiecutter.repo_name }}.__version__
 setup(
     name='{{ cookiecutter.project_name }}',
     version=version,
-    author='{{ cookiecutter.full_name }}',
+    author="{{ cookiecutter.author_name }}",
     author_email='{{ cookiecutter.email }}',
     packages=[
         '{{ cookiecutter.repo_name }}',


### PR DESCRIPTION
Replace `cookiecutter.full_name` with `cookiecutter.author_name`
The full name setting does not exist and creates a
blank author field in setup.py
