### PR TITLE
Set a more pleasant default project_name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "project_name is the title of the project.",
+    "project_name": "project_name",
     "repo_name": "{{ cookiecutter.project_name|replace(' ', '_') }}",
     "author_name": "Your Name",
     "email": "Your email",


### PR DESCRIPTION
This suggests a less daunting default `project_name` variable
Related to issue #167