### PR TITLE
Middleware security placed in production configuration

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -57,7 +57,6 @@ class Common(Configuration):
     # MIDDLEWARE CONFIGURATION
     MIDDLEWARE_CLASSES = (
         # Make sure djangosecure.middleware.SecurityMiddleware is listed first
-        'djangosecure.middleware.SecurityMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -37,6 +37,15 @@ class Production(Common):
     # django-secure
     INSTALLED_APPS += ("djangosecure", )
 
+    # MIDDLEWARE CONFIGURATION
+    MIDDLEWARE_CLASSES = (
+        # Make sure djangosecure.middleware.SecurityMiddleware is listed first
+        'djangosecure.middleware.SecurityMiddleware',
+    )
+
+    MIDDLEWARE_CLASSES += Common.MIDDLEWARE_CLASSES
+    # END MIDDLEWARE CONFIGURATION
+
     # set this to 60 seconds and then to 518400 when you can prove it works
     SECURE_HSTS_SECONDS = 60
     SECURE_HSTS_INCLUDE_SUBDOMAINS = values.BooleanValue(True)


### PR DESCRIPTION
https://github.com/pydanny/cookiecutter-django/issues/190

Security package is only defined in Production conf. Moved security middleware there, taking into account it should be the first defined in the list.