### PR TITLE
Updated INSTALLED_APPS for 'collectfast'.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -37,6 +37,7 @@ Martin Blech
 Andy Rose
 Andrew Mikhnevich / @zcho
 Kevin Ndung'u / @kevgathuku
+Kaveh / @ka7eh
 
 * Possesses commit rights
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -7,8 +7,6 @@ Production Configurations
 - Use sendgrid to send emails
 - Use MEMCACHIER on Heroku
 '''
-import django
-
 from configurations import values
 
 # See: http://django-storages.readthedocs.org/en/latest/backends/amazon-S3.html#settings
@@ -83,12 +81,10 @@ class Production(Common):
     AWS_AUTO_CREATE_BUCKET = True
     AWS_QUERYSTRING_AUTH = False
 
-    # see: https://github.com/antonagestam/collectfast
+    # See: https://github.com/antonagestam/collectfast
+    # For Django 1.7+, 'collectfast' should come before 'django.contrib.staticfiles'
     AWS_PRELOAD_METADATA = True
-    if django.VERSION < (1, 7):
-        INSTALLED_APPS += ('collectfast', )
-    else:
-        INSTALLED_APPS = ('collectfast', ) + INSTALLED_APPS
+    INSTALLED_APPS = ('collectfast', ) + INSTALLED_APPS
 
     # AWS cache settings, don't change unless you know what you're doing:
     AWS_EXPIRY = 60 * 60 * 24 * 7

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -7,6 +7,8 @@ Production Configurations
 - Use sendgrid to send emails
 - Use MEMCACHIER on Heroku
 '''
+import django
+
 from configurations import values
 
 # See: http://django-storages.readthedocs.org/en/latest/backends/amazon-S3.html#settings
@@ -83,7 +85,10 @@ class Production(Common):
 
     # see: https://github.com/antonagestam/collectfast
     AWS_PRELOAD_METADATA = True
-    INSTALLED_APPS += ('collectfast', )
+    if django.VERSION < (1, 7):
+        INSTALLED_APPS += ('collectfast', )
+    else:
+        INSTALLED_APPS = ('collectfast', ) + INSTALLED_APPS
 
     # AWS cache settings, don't change unless you know what you're doing:
     AWS_EXPIRY = 60 * 60 * 24 * 7


### PR DESCRIPTION
Quote from https://github.com/antonagestam/collectfast:
>For Django 1.7+, <code>'collectfast'</code> should come before <code>'django.contrib.staticfiles'</code>. For Django versions below 1.7, it should come after <code>'django.contrib.staticfiles'</code>. Please note, that failure to do so will cause Django to use <code>django.contrib.staticfiles</code>'s <code>collectstatic</code>.