### PR TITLE
Can't use AWS_STORAGE_BUCKET_NAME until post_setup.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -38,6 +38,7 @@ Andy Rose
 Andrew Mikhnevich / @zcho
 Kevin Ndung'u / @kevgathuku
 Kaveh / @ka7eh
+Jeff Johnson / @jeffcjohnson
 
 * Possesses commit rights
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -92,9 +92,6 @@ class Production(Common):
         'Cache-Control': 'max-age=%d, s-maxage=%d, must-revalidate' % (
             AWS_EXPIRY, AWS_EXPIRY)
     }
-
-    # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-    STATIC_URL = 'https://s3.amazonaws.com/%s/' % AWS_STORAGE_BUCKET_NAME
     # END STORAGE CONFIGURATION
 
     # EMAIL
@@ -130,3 +127,8 @@ class Production(Common):
     # END CACHING
 
     # Your production stuff: Below this line define 3rd party library settings
+
+    @classmethod
+    def post_setup(cls):
+        # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url
+        cls.STATIC_URL = 'https://s3.amazonaws.com/%s/' % cls.AWS_STORAGE_BUCKET_NAME


### PR DESCRIPTION
With old code:
STATIC_URL: "https://s3.amazonaws.com/&lt;Value default: None&gt;/"

With new code:
STATIC_URL: "https://s3.amazonaws.com/mybucket/"
