### PR TITLE
Implement basic substitution test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ language: python
 before_install:
   - time pip install pep8
 
+install:
+- pip install -r dev-requirements.txt
+
 script:
   - pep8 --ignore E201,E202 --max-line-length=120 --exclude='migrations' .
+  - make test
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	py.test -q tests/*.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+cookiecutter
+pep8
+pytest

--- a/tests/test_cookiecutter_substitution.py
+++ b/tests/test_cookiecutter_substitution.py
@@ -1,0 +1,41 @@
+import os
+import re
+import shutil
+import unittest
+from os.path import dirname, exists, join
+
+from cookiecutter.main import cookiecutter
+
+
+class TestCookiecutterSubstitution(unittest.TestCase):
+    """Test that all cookiecutter instances are substituted"""
+
+    cookiecutter(dirname(dirname(__file__)), no_input=True)
+
+    destpath = join(dirname(dirname(__file__)), 'project_name')
+
+    def tearDown(self):
+        if exists(self.destpath):
+            shutil.rmtree(self.destpath)
+
+    def test_all_cookiecutter_instances_are_substituted(self):
+        # Build a list containing absolute paths to the generated files
+        paths = [os.path.join(dirpath, file_path)
+                 for dirpath, subdirs, files in os.walk(self.destpath)
+                 for file_path in files]
+
+        # Construct the cookiecutter search pattern
+        pattern = "{{(\s?cookiecutter)[.](.*?)}}"
+        re_obj = re.compile(pattern)
+
+        # Assert that no match is found in any of the files
+        for path in paths:
+            for line in open(path, 'r'):
+                match = re_obj.search(line)
+                self.assertIsNone(
+                    match,
+                    "cookiecutter variable not replaced in {}".format(path))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
So I had a go at implementing basic testing for this cookiecutter.
This test checks that all `{{cookiecutter}}` variables have been substituted in the generated project. 
I am using py.test as the test runner. 
This could have been useful in detecting issues such as #185 
I would appreciate any feedback on how this could be improved.

Re: #186  #196 