### PR TITLE
update requirements

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -1,5 +1,5 @@
 # Bleeding edge Django
-django==1.7.7
+django>=1.7.7,<1.8
 
 # Configuration
 django-configurations==0.8
@@ -16,7 +16,7 @@ django-floppyforms==1.3.0
 django-model-utils==2.2
 
 # Images
-Pillow==2.7.0
+Pillow==2.8.1
 
 # For user registration, either via email or social
 # Well-built with regular release cycles!
@@ -33,6 +33,6 @@ django-autoslug==1.7.2
 django-avatar==2.0
 
 # Time zones support
-pytz==2014.10
+pytz==2015.2
 
 # Your custom requirements go here

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -2,8 +2,8 @@
 -r base.txt
 coverage==3.7.1
 Sphinx
-django-extensions==1.5.1
-Werkzeug==0.10.1
+django-extensions==1.5.2
+Werkzeug==0.10.4
 
 # django-debug-toolbar that works with Django 1.5+
 django-debug-toolbar==1.3.0

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -6,4 +6,4 @@ gunicorn==19.3.0
 django-storages==1.1.8
 Collectfast==0.2.1
 gevent==1.0.1
-boto==2.36.0
+boto==2.37.0


### PR DESCRIPTION
update versions of:
* Pillow to `2.8.1`
* pytz to `2015.2`
* django-extensions to `1.5.2`
* Werkzeug to `0.10.4`
* boto to `2.37.0`