### PR TITLE
Swap to django-storages-redux, an py3 compatible fork

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -38,6 +38,7 @@ Andy Rose
 Andrew Mikhnevich / @zcho
 Kevin Ndung'u / @kevgathuku
 Kaveh / @ka7eh
+Alex Tsai / @caffodian
 
 * Possesses commit rights
 

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -3,7 +3,7 @@
 -r base.txt
 
 gunicorn==19.3.0
-django-storages==1.1.8
+django-storages-redux==1.2.3
 Collectfast==0.2.1
 gevent==1.0.1
 boto==2.38.0


### PR DESCRIPTION
This is a bit silly (LOC-wise) but I saw #161, and since I've been doing this in some of my own projects, and thought this might be worth sharing.

[django-storages](https://pypi.python.org/pypi/django-storages) hasn't been updated in over 2 years at this point.  Around December a work [django-storages-redux](https://pypi.python.org/pypi/django-storages-redux/1.2.3) was started to fix various outstanding issues as well as to make it Python 3 compatible.  Not working with Py3 and S3 myself, I can't speak to whether this fixes #161 for free or not, but I have found value in the extra 2 years of bugfix commits ;)  

thanks!