### PR TITLE
Fixed a bug with escaped spaces in Cache-Control.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -70,8 +70,9 @@ INSTALLED_APPS = ('collectfast', ) + INSTALLED_APPS
 # AWS cache settings, don't change unless you know what you're doing:
 AWS_EXPIRY = 60 * 60 * 24 * 7
 AWS_HEADERS = {
-    'Cache-Control': 'max-age=%d, s-maxage=%d, must-revalidate' % (
-        AWS_EXPIRY, AWS_EXPIRY)
+    'Cache-Control': str.encode(
+        'max-age=%d, s-maxage=%d, must-revalidate' % (
+            AWS_EXPIREY, AWS_EXPIREY))
 }
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -69,6 +69,10 @@ INSTALLED_APPS = ('collectfast', ) + INSTALLED_APPS
 
 # AWS cache settings, don't change unless you know what you're doing:
 AWS_EXPIRY = 60 * 60 * 24 * 7
+
+# TODO See: https://github.com/jschneier/django-storages/issues/47
+# Revert the following and use str after the above-mentioned bug is fixed in
+# either django-storage-redux or boto
 AWS_HEADERS = {
     'Cache-Control': str.encode(
         'max-age=%d, s-maxage=%d, must-revalidate' % (


### PR DESCRIPTION
It seems there's a bug in boto that causes spaces in Cache-Control get escaped. (see: https://github.com/boto/boto/issues/2536)
For me, the header for static files rendered as this: 'max-age=604800,%20s-maxage=604800,%20must-revalidate' (under python 3 and django 1.7.7)
Turning the string into bytestring solved the issue for me, though I haven't tested it under other versions of python/django.
