### PR TITLE
Fix APPS_DIR to move up to config

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, unicode_literals
 
 import environ
 
-APPS_DIR = environ.Path(__file__) - 1  # one folder back (/a/b/ - 1 = /a/)
+APPS_DIR = environ.Path(__file__) - 2  # one folder back (/a/b/ - 1 = /a/)
 ROOT_DIR = APPS_DIR - 1
 
 env = environ.Env()


### PR DESCRIPTION
```
In [2]: environ.Path('/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py')
Out[2]: <Path:/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py>

In [3]: environ.Path('/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py') -1
Out[3]: <Path:/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config>

In [4]: environ.Path('/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py') - 2
Out[4]: <Path:/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}>
```
I believe we don't want store data (see STATICFILES_DIRS) in config directory.