### PR TITLE
Inconsistent use of 'AWS_EXPIRY'

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -82,7 +82,7 @@ AWS_EXPIRY = 60 * 60 * 24 * 7
 AWS_HEADERS = {
     'Cache-Control': str.encode(
         'max-age=%d, s-maxage=%d, must-revalidate' % (
-            AWS_EXPIREY, AWS_EXPIREY))
+            AWS_EXPIRY, AWS_EXPIRY))
 }
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url


### PR DESCRIPTION
'AWS_EXPIREY' should be 'AWS_EXPIRY', as spelled earlier in the file.