### PR TITLE
Update common.py postgres connection string

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,6 @@
     "timezone": "UTC",
     "now": "2015/01/13",
     "year": "{{ cookiecutter.now[:4] }}",
-    "use_whitenoise": "y"
+    "use_whitenoise": "y",
+    "windows": "n"
 }

--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -102,7 +102,7 @@ MANAGERS = ADMINS
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {
     # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
-    'default': env.db("DATABASE_URL", default="postgres://localhost/{{cookiecutter.repo_name}}"),
+    'default': env.db("DATABASE_URL", default="postgres:///{{cookiecutter.repo_name}}"),
 }
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 

--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -102,7 +102,7 @@ MANAGERS = ADMINS
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {
     # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
-    'default': env.db("DATABASE_URL", default="postgres:///{{cookiecutter.repo_name}}"),
+    'default': env.db("DATABASE_URL", default="postgres://{% if cookiecutter.windows == 'y' %}localhost{% endif %}/{{cookiecutter.repo_name}}"),
 }
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 


### PR DESCRIPTION
By removing localhost we enable the default use of Unix sockets which integrates better with the postgresql access rights in pg_hba.conf.