### PR TITLE
Docker Compose development environment

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -33,7 +33,7 @@ Chris Franklin
 Benjamin Abel
 Felipe Arruda / @arruda
 Matt Warren / @mfwarren
-Martin Blech
+Martin Blech / @martinblech
 Andy Rose
 Andrew Mikhnevich / @zcho
 Kevin Ndung'u / @kevgathuku

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,22 @@ To get live reloading to work you'll probably need to install an `appropriate br
 
 .. _appropriate browser extension: http://feedback.livereload.com/knowledgebase/articles/86242-how-do-i-install-and-use-the-browser-extensions-
 
+**Running in an isolated Docker development environment**
+
+If you would rather run your application inside a separate Docker environment and avoid installing Postgres or any dependencies in your host OS, you can use the included Docker Compose configuration (``Dockerfile`` and ``docker-compose.yml``).
+
+Make sure that Docker_ is installed. In the project root run::
+
+    $ docker-compose up
+
+.. _Docker: https://docs.docker.com/installation/
+
+This command will download all the necessary dependencies and start your project. The first time, you will also need to run the following command to initialize the database::
+
+    $ docker-compose web python manage.py migrate
+
+If you're on OS X or Windows, run ``boot2docker ip`` to find out Docker's IP, otherwise it's localhost. Hit ``http://<docker_host>:8000/`` with your browser and you're ready to go.
+
 It's time to write the code!!!
 
 For Readers of Two Scoops of Django 1.8

--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -1,0 +1,10 @@
+# Only intended for development purposes.
+# For production deployment options, see the Deployment section in
+# README.rst
+
+FROM python:3.4
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+ADD . /code/
+RUN pip install -r requirements/local.txt

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -78,6 +78,22 @@ To get live reloading to work you'll probably need to install an `appropriate br
 
 .. _appropriate browser extension: http://feedback.livereload.com/knowledgebase/articles/86242-how-do-i-install-and-use-the-browser-extensions-
 
+**Running in an isolated Docker development environment**
+
+If you would rather run your application inside a separate Docker environment and avoid installing Postgres or any dependencies in your host OS, you can use the included Docker Compose configuration (``Dockerfile`` and ``docker-compose.yml``).
+
+Make sure that Docker_ is installed. In the project root run::
+
+    $ docker-compose up
+
+.. _Docker: https://docs.docker.com/installation/
+
+This command will download all the necessary dependencies and start your project. The first time, you will also need to run the following command to initialize the database::
+
+    $ docker-compose web python manage.py migrate
+
+If you're on OS X or Windows, run ``boot2docker ip`` to find out Docker's IP, otherwise it's localhost. Hit ``http://<docker_host>:8000/`` with your browser and you're ready to go.
+
 It's time to write the code!!!
 
 

--- a/{{cookiecutter.repo_name}}/docker-compose.yml
+++ b/{{cookiecutter.repo_name}}/docker-compose.yml
@@ -1,0 +1,17 @@
+# Only intended for development purposes.
+# For production deployment options, see the Deployment section in
+# README.rst
+
+db:
+  image: postgres
+web:
+  build: .
+  command: python manage.py runserver_plus 0.0.0.0:8000
+  volumes:
+    - .:/code
+  ports:
+    - "8000:8000"
+  links:
+    - db
+  environment:
+    - DATABASE_URL=postgres://postgres:postgres@db/postgres


### PR DESCRIPTION
Vagrant support was dropped in favor of Docker based development environments, but no replacement was provided. This should do.