### PR TITLE
Include LOCAL_APPS before THIRD_PARTY_APPS in INSTALLED_APPS

### DIFF
--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -48,7 +48,7 @@ LOCAL_APPS = (
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
-INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS + THIRD_PARTY_APPS
 
 # MIDDLEWARE CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This allows custom User model to be registered before THIRD_PARTY_APPS are imported.
THIRD_PARTY_APPS can now get the model registered with AUTH_USER_MODEL without throwing a LookupError.

This particular error was seen when using Django-CMS with this cookiecutter.