### PR TITLE
Add PostgreSQL createdb instructions to generated README.

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -56,6 +56,10 @@ First make sure to create and activate a virtualenv_, then open a terminal at th
 
 .. _virtualenv: http://docs.python-guide.org/en/latest/dev/virtualenvs/
 
+Create a local PostgreSQL database::
+
+    $ createdb {{ cookiecutter.repo_name }}
+
 You can now run the ``runserver_plus`` command::
 
     $ python manage.py runserver_plus


### PR DESCRIPTION
Before running `runserver_plus`, you need to create the local Postgres db. This adds instructions to the README on how to do this.