### PR TITLE
Use maildump instead of ConsoleEmailHandler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Features
 * Media storage using Amazon S3
 * Serve static files from Amazon S3 or Whitenoise_ (optional)
 * Pre configured Celery_ (optional)
+* Integration with Maildump_ for local email testing (optional)
 
 .. _Bootstrap: https://github.com/twbs/bootstrap
 .. _AngularJS: https://github.com/angular/angular.js
@@ -39,6 +40,7 @@ Features
 .. _Mailgun: https://mailgun.com/
 .. _Whitenoise: https://whitenoise.readthedocs.org/
 .. _Celery: http://www.celeryproject.org/
+.. _Maildump: https://github.com/ThiefMaster/maildump
 
 
 Constraints

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,5 +11,6 @@
     "year": "{{ cookiecutter.now[:4] }}",
     "use_whitenoise": "y",
     "use_celery": "n",
+    "use_maildump": "n",
     "windows": "n"
 }

--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -21,7 +21,8 @@ module.exports = function (grunt) {
       fonts: this.app + '/static/fonts',
       images: this.app + '/static/images',
       js: this.app + '/static/js',
-      manageScript: 'manage.py'
+      manageScript: 'manage.py',
+      mailserverpid: 'mailserver.pid',
     }
   };
 
@@ -82,7 +83,13 @@ module.exports = function (grunt) {
       },
       runDjango: {
         cmd: 'python <%= paths.manageScript %> runserver'
-      }
+      },
+      runMailDump: {
+        cmd: 'maildump -p <%= paths.mailserverpid %>'
+      },
+      stopMailDump: {
+        cmd: 'maildump -p <%= paths.mailserverpid %> --stop'
+      },
     }
   });
 
@@ -97,5 +104,13 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', [
     'build'
+  ]);
+
+  grunt.registerTask('start-email-server', [
+      'bgShell:runMailDump'
+  ]);
+
+  grunt.registerTask('stop-email-server', [
+      'bgShell:stopMailDump'
   ]);
 };

--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
       images: this.app + '/static/images',
       js: this.app + '/static/js',
       manageScript: 'manage.py',
-      mailserverpid: 'mailserver.pid',
+      {% if cookiecutter.use_maildump=="y" -%}mailserverpid: 'mailserver.pid',{%- endif %}
     }
   };
 
@@ -84,12 +84,12 @@ module.exports = function (grunt) {
       runDjango: {
         cmd: 'python <%= paths.manageScript %> runserver'
       },
-      runMailDump: {
+      {% if cookiecutter.use_maildump == "y" -%}runMailDump: {
         cmd: 'maildump -p <%= paths.mailserverpid %>'
       },
       stopMailDump: {
         cmd: 'maildump -p <%= paths.mailserverpid %> --stop'
-      },
+      },{%- endif %}
     }
   });
 
@@ -105,12 +105,12 @@ module.exports = function (grunt) {
   grunt.registerTask('default', [
     'build'
   ]);
-
+  {% if cookiecutter.use_maildump == "y" -%}
   grunt.registerTask('start-email-server', [
       'bgShell:runMailDump'
   ]);
 
   grunt.registerTask('stop-email-server', [
       'bgShell:stopMailDump'
-  ]);
+  ]);{%- endif %}
 };

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -126,7 +126,7 @@ To run a celery worker:
 
 Please note: For Celerys import magic to work, it is important *where* the celery commands are run. If you are in the same folder with *manage.py*, you should be right.
 {% endif %}
-
+{% if cookiecutter.use_maildump == "y" %}
 Email Server
 ^^^^^^^^^^^^
 
@@ -147,6 +147,7 @@ To stop the email server::
     $ grunt stop-email-server
 
 The email server listens on 127.0.0.1:1025
+{% endif %}
 
 It's time to write the code!!!
 

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -133,6 +133,8 @@ Email Server
 In development, it is often nice to be able to see emails that are being sent from your application. For this purpose,
 a Grunt task exists to start an instance of `maildump`_ which is a local SMTP server with an online interface.
 
+.. _maildump: https://github.com/ThiefMaster/maildump
+
 Make sure you have nodejs installed, and then type the following::
 
     $ grunt start-email-server

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -127,6 +127,25 @@ To run a celery worker:
 Please note: For Celerys import magic to work, it is important *where* the celery commands are run. If you are in the same folder with *manage.py*, you should be right.
 {% endif %}
 
+Email Server
+^^^^^^^^^^^^
+
+In development, it is often nice to be able to see emails that are being sent from your application. For this purpose,
+a Grunt task exists to start an instance of `maildump`_ which is a local SMTP server with an online interface.
+
+Make sure you have nodejs installed, and then type the following::
+
+    $ grunt start-email-server
+
+This will start an email server. The project is setup to deliver to the email server by default. To view messages
+that are sent by your application, open your browser to http://127.0.0.1:1080
+
+To stop the email server::
+
+    $ grunt stop-email-server
+
+The email server listens on 127.0.0.1:1025
+
 It's time to write the code!!!
 
 

--- a/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -25,8 +25,6 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default='CHANGEME!!!')
 # ------------------------------------------------------------------------------
 EMAIL_HOST = 'localhost'
 EMAIL_PORT = 1025
-EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',
-                    default='django.core.mail.backends.console.EmailBackend')
 
 # CACHING
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -25,6 +25,10 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default='CHANGEME!!!')
 # ------------------------------------------------------------------------------
 EMAIL_HOST = 'localhost'
 EMAIL_PORT = 1025
+{%if cookiecutter.use_maildump == "n" -%}
+EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',
+                    default='django.core.mail.backends.console.EmailBackend')
+{%- endif %}
 
 # CACHING
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -10,3 +10,6 @@ django-debug-toolbar==1.3.2
 
 # improved REPL
 ipdb==0.8.1
+
+# maildump
+maildump==0.5.1

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -12,6 +12,6 @@ django-debug-toolbar==1.3.2
 ipdb==0.8.1
 
 {% if cookiecutter.use_maildump == "y" -%}
-# maildump
+# Enables better email testing
 maildump==0.5.1
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -11,5 +11,7 @@ django-debug-toolbar==1.3.2
 # improved REPL
 ipdb==0.8.1
 
+{% if cookiecutter.use_maildump == "y" -%}
 # maildump
 maildump==0.5.1
+{%- endif %}


### PR DESCRIPTION
In development, the `ConsoleEmailHandler` is of limited use if you are sending emails with attachments, or any HTML message.

I propose integrating with [maildump](https://github.com/ThiefMaster/maildump) a Python clone of [mailcatcher](http://mailcatcher.me/) which is a ruby application.

It provides a local SMTP server listening on 1025, and an interface that shows multi-part emails and HTML formatted emails correctly, available at http://127.0.0.1:1080:

![image](https://cloud.githubusercontent.com/assets/603112/8558781/95551ea4-250f-11e5-9f1c-73a321680da4.png)

The way I use it is through two grunt tasks, `start-email-server` and `stop-email-server`.