### PR TITLE
add 'default' named parameter to 'env' function which sets the SERVER_EMAIL Django setting

### DIFF
--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -106,7 +106,7 @@ EMAIL_BACKEND = 'django_mailgun.MailgunBackend'
 MAILGUN_ACCESS_KEY = env('DJANGO_MAILGUN_API_KEY')
 MAILGUN_SERVER_NAME = env('DJANGO_MAILGUN_SERVER_NAME')
 EMAIL_SUBJECT_PREFIX = env("DJANGO_EMAIL_SUBJECT_PREFIX", default='[{{cookiecutter.project_name}}] ')
-SERVER_EMAIL = env('DJANGO_SERVER_EMAIL', DEFAULT_FROM_EMAIL)
+SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default="DEFAULT_FROM_EMAIL")
 
 # TEMPLATE CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #268