### PR TITLE
Refactor choice of settings module out of taskapp/celery.py

### DIFF
--- a/{{cookiecutter.repo_name}}/config/celery_config.py
+++ b/{{cookiecutter.repo_name}}/config/celery_config.py
@@ -1,0 +1,4 @@
+# This tells Celery which Django settings module it should use.
+# This decouples the taskapp configuration from a specific instance of the project.
+
+DJANGO_SETTINGS_MODULE = 'config.settings.local'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/taskapp/celery.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/taskapp/celery.py
@@ -4,10 +4,11 @@ import os
 from celery import Celery
 from django.apps import AppConfig
 from django.conf import settings
+from config import celery_config
 
 if not settings.configured:
     # set the default Django settings module for the 'celery' program.
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", celery_config.DJANGO_SETTINGS_MODULE)
 
 
 app = Celery('{{cookiecutter.repo_name}}')


### PR DESCRIPTION
…s module. This makes it necessary to edit `taskapp/celery.py` after deployment, which is not ideal.

This moves the choice of a settings module to config/celery_config.py, where it belongs.