### PR TITLE
Update heroku deploy docs

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -173,7 +173,7 @@ Run these commands to deploy the project to Heroku:
     heroku addons:create mailgun
     heroku addons:create memcachier:dev
 
-    heroku config:set DJANGO_SECRET_KEY=RANDOM_SECRET_KEY_HERE
+    heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 32`
     heroku config:set DJANGO_SETTINGS_MODULE='config.settings.production'
 
     heroku config:set DJANGO_AWS_ACCESS_KEY_ID=YOUR_AWS_ID_HERE

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -183,6 +183,8 @@ Run these commands to deploy the project to Heroku:
     heroku config:set DJANGO_MAILGUN_SERVER_NAME=YOUR_MALGUN_SERVER
     heroku config:set DJANGO_MAILGUN_API_KEY=YOUR_MAILGUN_API_KEY
     
+    heroku config:set PYTHONHASHSEED=random
+    
     git push heroku master
     heroku run python manage.py migrate
     heroku run python manage.py check --deploy

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -166,8 +166,8 @@ Run these commands to deploy the project to Heroku:
 
     heroku create --buildpack https://github.com/heroku/heroku-buildpack-python
 
-    heroku addons:create heroku-postgresql:dev
-    heroku pg:backups schedule DATABASE_URL
+    heroku addons:create heroku-postgresql:hobby-dev
+    heroku pg:backups schedule --at '02:00 America/Los_Angeles' DATABASE_URL
     heroku pg:promote DATABASE_URL
 
     heroku addons:create mailgun
@@ -181,7 +181,8 @@ Run these commands to deploy the project to Heroku:
     heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME=YOUR_AWS_S3_BUCKET_NAME_HERE
 
     heroku config:set DJANGO_MAILGUN_SERVER_NAME=YOUR_MALGUN_SERVER
-
+    heroku config:set DJANGO_MAILGUN_API_KEY=YOUR_MAILGUN_API_KEY
+    
     git push heroku master
     heroku run python manage.py migrate
     heroku run python manage.py check --deploy


### PR DESCRIPTION
- Heroku's free postgres tier is now "hobby-dev"
- pg:backups require a scheduled time
- add missing Mailgun API key
- Django recommends setting the PYTHONHASHSEED environment variable to random.  See: https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/#python-options
- Use openssl to generate a secure, random secret_key