### PR TITLE
Add .pep8 and .pylintrc, for #282

### DIFF
--- a/{{cookiecutter.repo_name}}/.pep8
+++ b/{{cookiecutter.repo_name}}/.pep8
@@ -1,0 +1,3 @@
+[pep8]
+max-line-length = 120
+exclude=*/migrations/*

--- a/{{cookiecutter.repo_name}}/.pylintrc
+++ b/{{cookiecutter.repo_name}}/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+load-plugins=pylint_common, pylint_django{% if cookiecutter.use_celery == "y" %}, pylint_celery {% endif %}
+
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+disable=missing-docstring,invalid-name
+
+[DESIGN]
+max-parents=13

--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -256,11 +256,14 @@ LOGGING = {
     }
 }
 {% if cookiecutter.use_celery == "y" %}
-########## CELERY
+# ######### CELERY
 INSTALLED_APPS += ('{{cookiecutter.repo_name}}.taskapp.celery.CeleryConfig',)
 # if you are not using the django database broker (e.g. rabbitmq, redis, memcached), you can remove the next line.
 INSTALLED_APPS += ('kombu.transport.django',)
 BROKER_URL = env("CELERY_BROKER_URL", default='django://')
-########## END CELERY
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+# ######### END CELERY
 {% endif %}
 # Your common stuff: Below this line define 3rd party library settings

--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -256,14 +256,11 @@ LOGGING = {
     }
 }
 {% if cookiecutter.use_celery == "y" %}
-# ######### CELERY
+########## CELERY
 INSTALLED_APPS += ('{{cookiecutter.repo_name}}.taskapp.celery.CeleryConfig',)
 # if you are not using the django database broker (e.g. rabbitmq, redis, memcached), you can remove the next line.
 INSTALLED_APPS += ('kombu.transport.django',)
 BROKER_URL = env("CELERY_BROKER_URL", default='django://')
-CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-# ######### END CELERY
+########## END CELERY
 {% endif %}
 # Your common stuff: Below this line define 3rd party library settings


### PR DESCRIPTION
Here is what the defaults would look like to make the generated project pass most of the strict checking.
With these .rc files, prospector shows only 8 violations currently, all minor and easy to clean up.