### PR TITLE
Grunt Updates: use libsass, add postcss

### DIFF
--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -87,7 +87,16 @@ module.exports = function (grunt) {
 
         processors: [
           require('pixrem')(), // add fallbacks for rem units
-          require('autoprefixer-core')({browsers: 'last 2 versions'}), // add vendor prefixes
+          require('autoprefixer-core')({browsers: [
+            'Android 2.3',
+            'Android >= 4',
+            'Chrome >= 20',
+            'Firefox >= 24',
+            'Explorer >= 8',
+            'iOS >= 6',
+            'Opera >= 12',
+            'Safari >= 6'
+          ]}), // add vendor prefixes
           require('cssnano')() // minify the result
         ]
       },

--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -36,9 +36,12 @@ module.exports = function (grunt) {
       gruntfile: {
         files: ['Gruntfile.js']
       },
-      compass: {
+      sass: {
         files: ['<%= paths.sass %>/**/*.{scss,sass}'],
-        tasks: ['compass:server']
+        tasks: ['sass:dev'],
+        options: {
+          atBegin: true
+        }
       },
       livereload: {
         files: [
@@ -53,26 +56,43 @@ module.exports = function (grunt) {
       },
     },
 
-    // see: https://github.com/gruntjs/grunt-contrib-compass
-    compass: {
-      options: {
-          sassDir: '<%= paths.sass %>',
-          cssDir: '<%= paths.css %>',
-          fontsDir: '<%= paths.fonts %>',
-          imagesDir: '<%= paths.images %>',
-          relativeAssets: false,
-          assetCacheBuster: false,
-          raw: 'Sass::Script::Number.precision = 10\n'
+    // see: https://github.com/sindresorhus/grunt-sass
+    sass: {
+      dev: {
+          options: {
+              outputStyle: 'nested',
+              sourceMap: false,
+              precision: 10
+          },
+          files: {
+              '<%= paths.css %>/project.css': '<%= paths.sass %>/project.scss'
+          },
       },
       dist: {
-        options: {
-          environment: 'production'
-        }
+          options: {
+              outputStyle: 'compressed',
+              sourceMap: false,
+              precision: 10
+          },
+          files: {
+              '<%= paths.css %>/project.css': '<%= paths.sass %>/project.scss'
+          },
+      }
+    },
+    
+    //see https://github.com/nDmitry/grunt-postcss
+    postcss: {
+      options: {
+        map: true, // inline sourcemaps
+
+        processors: [
+          require('pixrem')(), // add fallbacks for rem units
+          require('autoprefixer-core')({browsers: 'last 2 versions'}), // add vendor prefixes
+          require('cssnano')() // minify the result
+        ]
       },
-      server: {
-        options: {
-          // debugInfo: true
-        }
+      dist: {
+        src: '<%= paths.css %>/*.css'
       }
     },
 
@@ -99,7 +119,8 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('build', [
-    'compass:dist'
+    'sass:dist',
+    'postcss'
   ]);
 
   grunt.registerTask('default', [

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -3,13 +3,16 @@
   "version": "{{ cookiecutter.version }}",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt": "~0.4.5",
+    "grunt-contrib-watch": "~0.6.1",
     "grunt-bg-shell": "~2.3.1",
     "connect-livereload": "~0.3.2",
-    "grunt-contrib-compass": "~0.7.0",
-    "time-grunt": "~0.2.7",
-    "load-grunt-tasks": "~0.2.1"
+    "time-grunt": "~1.2.1",
+    "load-grunt-tasks": "~3.2.0",
+    "grunt-sass": "~1.0.0",
+    "grunt-postcss": "~0.5.5",
+    "cssnano": "~2.1.0",
+    "autoprefixer-core": "~5.2.1"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -12,7 +12,8 @@
     "grunt-sass": "~1.0.0",
     "grunt-postcss": "~0.5.5",
     "cssnano": "~2.1.0",
-    "autoprefixer-core": "~5.2.1"
+    "autoprefixer-core": "~5.2.1",
+    "pixrem": "~1.3.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Changes:
- Updated Npm dependencies
- Use grunt-sass instead of grunt-contrib-sass/compass
- Update grunt build task to use postcss with autoprefixer, cssnano and pixrem

Notes:
- Compass is  incompatible with libsass (bourbon is great substitute and is available via bower with no dependencies)
- Added autoprefixer/postcss which is required to compile bootstrap-sass 
- Added css minification to the grunt build task with cssnano

Sorry for messy commits, I can squash if necessary 