### PR TITLE
Added vagrant support with automatic provisioning of dependencies and PostgreSQL

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -51,6 +51,7 @@ Burhan Khalid / @burhan
 Jannis Gebauer / @got_nil
 jayfk / @jayfk
 stepmr / @stepmr 
+Javi Palanca / @javipalanca
 
 * Possesses commit rights
 

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -54,3 +54,6 @@ node_modules/
 
 # virtual environments
 .env
+
+# Vagrant
+.vagrant

--- a/{{cookiecutter.repo_name}}/Vagrantfile
+++ b/{{cookiecutter.repo_name}}/Vagrantfile
@@ -1,0 +1,77 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "utopic64"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/utopic/current/utopic-server-cloudimg-amd64-vagrant-disk1.box"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 8000, host: 9000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", inline: <<-SHELL
+     cd /vagrant && ./install_os_dependencies.sh install
+     su vagrant -c ". /usr/share/virtualenvwrapper/virtualenvwrapper.sh && mkvirtualenv {{ cookiecutter.repo_name }} --python=/usr/bin/python3"
+     su vagrant -c ". /usr/share/virtualenvwrapper/virtualenvwrapper.sh && workon {{ cookiecutter.repo_name }} && cd /vagrant && ./install_python_dependencies.sh"
+     apt-get install -y postgresql
+     sudo -u postgres psql -c "CREATE USER vagrant;"
+     sudo -u postgres psql -c "CREATE DATABASE {{ cookiecutter.repo_name }} OWNER vagrant;"
+   SHELL
+
+end

--- a/{{cookiecutter.repo_name}}/requirements.apt
+++ b/{{cookiecutter.repo_name}}/requirements.apt
@@ -5,6 +5,11 @@ build-essential
 gettext
 python-dev
 
+##python3
+python3
+python3-dev
+virtualenvwrapper
+
 ##shared dependencies of:
 ##Pillow, pylibmc
 zlib1g-dev
@@ -13,7 +18,7 @@ zlib1g-dev
 libpq-dev
 
 ##Pillow dependencies
-libtiff4-dev
+libtiff5-dev
 libjpeg8-dev
 libfreetype6-dev
 liblcms1-dev

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -4,7 +4,7 @@
 
 # WSGI Handler
 # ------------------------------------------------
-gevent==1.0.2
+# gevent==1.0.2
 gunicorn==19.3.0
 
 # Static and Media Storage


### PR DESCRIPTION
I've added a Vagrantfile that allows developers to automatically run a vagrant image (utopic64) wich is provisioned with all dependencies (os and python), creates a virtualenv and installs PostgreSQL with the default database for local development.
It also installs python3. I've updated libtiff4-dev to libtiff5-dev. I had to comment gevent since it is not python3 compatible.
Hope this helps!