### PR TITLE
fixing a bug in the allauth configuration

### DIFF
--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -152,8 +152,6 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
-                'allauth.account.context_processors.account',
-                'allauth.socialaccount.context_processors.socialaccount',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',


### PR DESCRIPTION
The [last commit](https://github.com/pydanny/cookiecutter-django/commit/222635bf85af58fd505c2e2fc137efa06f7604d8) upgraded `django-allauth`; unfortunately this change (from 0.21 to 0.22) forces a change in settings which was not applied; causing the following exception if someone excepts all default values:

```
Environment:


Request Method: GET
Request URL: http://localhost:8000/

Django Version: 1.8.3
Python Version: 2.7.9
Installed Applications:
(u'django.contrib.auth',
 u'django.contrib.contenttypes',
 u'django.contrib.sessions',
 u'django.contrib.sites',
 u'django.contrib.messages',
 u'django.contrib.staticfiles',
 u'django.contrib.admin',
 u'crispy_forms',
 u'allauth',
 u'allauth.account',
 u'allauth.socialaccount',
 u'project_name.users',
 'debug_toolbar',
 'django_extensions')
Installed Middleware:
(u'django.contrib.sessions.middleware.SessionMiddleware',
 u'django.middleware.common.CommonMiddleware',
 u'django.middleware.csrf.CsrfViewMiddleware',
 u'django.contrib.auth.middleware.AuthenticationMiddleware',
 u'django.contrib.messages.middleware.MessageMiddleware',
 u'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'debug_toolbar.middleware.DebugToolbarMiddleware')


Traceback:
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  164.                 response = response.render()
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/template/response.py" in render
  158.             self.content = self.rendered_content
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/template/response.py" in rendered_content
  135.         content = template.render(context, self._request)
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/template/backends/django.py" in render
  74.         return self.template.render(context)
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/template/base.py" in render
  208.                 with context.bind_template(self):
File "/usr/lib/python2.7/contextlib.py" in __enter__
  17.             return self.gen.next()
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/debug_toolbar/panels/templates/panel.py" in _request_context_bind_template
  72.         processors = (template.engine.template_context_processors +
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/utils/functional.py" in __get__
  60.         res = instance.__dict__[self.name] = self.func(instance)
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/template/engine.py" in template_context_processors
  90.         return tuple(import_string(path) for path in context_processors)
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/template/engine.py" in <genexpr>
  90.         return tuple(import_string(path) for path in context_processors)
File "/home/burhan/work/envs/project_name/local/lib/python2.7/site-packages/django/utils/module_loading.py" in import_string
  26.     module = import_module(module_path)
File "/usr/lib/python2.7/importlib/__init__.py" in import_module
  37.     __import__(name)

Exception Type: ImportError at /
Exception Value: No module named context_processors
```

This pull request fixes the settings to mitigate this bug.