### PR TITLE
Upgrade to Bootstrap 4 alpha

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/css/project.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/css/project.css
@@ -32,3 +32,8 @@
   background-color: #f2dede;
   border-color: #eed3d7;
 }
+
+/* line 36, ../sass/project.scss */
+.navbar-header {
+  margin-bottom: 3rem;
+}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/sass/project.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/sass/project.scss
@@ -31,3 +31,8 @@
   background-color: #f2dede;
   border-color: #eed3d7;
 }
+
+// Give header a nice bottom margin
+.navbar-header {
+  margin-bottom: 3rem;
+}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -32,7 +32,7 @@
   <body>
 
     <nav class="navbar navbar-dark navbar-static-top bg-inverse">
-      <div class="container-fluid">
+      <div class="container">
         <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
         <button type="button" class="navbar-toggler hidden-sm-up pull-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">
           &#9776;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -31,7 +31,7 @@
 
   <body>
 
-    <nav class="navbar navbar-default">
+    <nav class="navbar navbar-dark navbar-static-top bg-inverse">
       <div class="container-fluid">
         <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
         <button type="button" class="navbar-toggler hidden-sm-up pull-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -15,10 +15,7 @@
 
     {% block css %}
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-
-    <!-- Optional theme -->
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/css/bootstrap.css">
 
     <!-- Your stuff: Third-party css libraries go here -->
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -79,10 +79,10 @@
     <!-- Placed at the end of the document so the pages load faster -->
     {% block javascript %}
       <!-- Latest JQuery -->
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
 
       <!-- Latest compiled and minified JavaScript -->
-      <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+      <script src="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/js/bootstrap.js"></script>
 
       <!-- Your stuff: Third-party javascript libraries go here -->
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -30,33 +30,35 @@
   </head>
 
   <body>
-
-    <nav class="navbar navbar-dark navbar-static-top bg-inverse">
-      <div class="container">
-        <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
-        <button type="button" class="navbar-toggler hidden-sm-up pull-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">
-          &#9776;
-        </button>
+    
+    <div class="navbar-header">
+      <nav class="navbar navbar-dark navbar-static-top bg-inverse">
+        <div class="container">
+          <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
+          <button type="button" class="navbar-toggler hidden-sm-up pull-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">
+            &#9776;
+          </button>
           
-        <!-- Collect the nav links, forms, and other content for toggling -->
-        <div class="collapse navbar-toggleable-xs" id="bs-navbar-collapse-1">
-          <ul class="nav navbar-nav">
-            <li class="nav-item"><a class="nav-link" href="{% url 'home' %}">Home</a></li>
-            <li class="nav-item"><a class="nav-link" href="{% url 'about' %}">About</a></li>
-          </ul>
+          <!-- Collect the nav links, forms, and other content for toggling -->
+          <div class="collapse navbar-toggleable-xs" id="bs-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+              <li class="nav-item"><a class="nav-link" href="{% url 'home' %}">Home</a></li>
+              <li class="nav-item"><a class="nav-link" href="{% url 'about' %}">About</a></li>
+            </ul>
         
-          <ul class="nav navbar-nav pull-right">
-            {% if request.user.is_authenticated %}
-              <li class="nav-item"><a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a></li>
-              <li class="nav-item"><a class="nav-link" href="{% url 'account_logout' %}">{% trans "Logout" %}</a></li>
-            {% else %}
-              <li class="nav-item"><a class="nav-link" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a></li>
-              <li class="nav-item"><a class="nav-link" href="{% url 'account_login' %}">{% trans "Log In" %}</a></li>
-            {% endif %}
-          </ul>
+            <ul class="nav navbar-nav pull-right">
+              {% if request.user.is_authenticated %}
+                <li class="nav-item"><a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a></li>
+                <li class="nav-item"><a class="nav-link" href="{% url 'account_logout' %}">{% trans "Logout" %}</a></li>
+              {% else %}
+                <li class="nav-item"><a class="nav-link" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a></li>
+                <li class="nav-item"><a class="nav-link" href="{% url 'account_login' %}">{% trans "Log In" %}</a></li>
+              {% endif %}
+            </ul>
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
+    </div>
 
     <div class="container">
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -34,38 +34,32 @@
 
   <body>
 
-    <div class="navbar navbar-default">
+    <nav class="navbar navbar-default">
       <div class="container-fluid">
-        <!-- Brand and toggle get grouped for better mobile display -->
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-navbar-collapse-1" aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
-        </div>
+        <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
+        <button type="button" class="navbar-toggler hidden-sm-up pull-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">
+          &#9776;
+        </button>
           
         <!-- Collect the nav links, forms, and other content for toggling -->
-        <div class="collapse navbar-collapse" id="bs-navbar-collapse-1">
+        <div class="collapse navbar-toggleable-xs" id="bs-navbar-collapse-1">
           <ul class="nav navbar-nav">
-            <li><a href="{% url 'home' %}">Home</a></li>
-            <li><a href="{% url 'about' %}">About</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'home' %}">Home</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'about' %}">About</a></li>
           </ul>
         
-          <ul class="nav navbar-nav navbar-right">
+          <ul class="nav navbar-nav pull-right">
             {% if request.user.is_authenticated %}
-              <li><a href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a></li>
-              <li><a href="{% url 'account_logout' %}">{% trans "Logout" %}</a></li>
+              <li class="nav-item"><a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a></li>
+              <li class="nav-item"><a class="nav-link" href="{% url 'account_logout' %}">{% trans "Logout" %}</a></li>
             {% else %}
-              <li><a href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a></li>
-              <li><a href="{% url 'account_login' %}">{% trans "Log In" %}</a></li>
+              <li class="nav-item"><a class="nav-link" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a></li>
+              <li class="nav-item"><a class="nav-link" href="{% url 'account_login' %}">{% trans "Log In" %}</a></li>
             {% endif %}
           </ul>
         </div>
       </div>
-    </div>
+    </nav>
 
     <div class="container">
 


### PR DESCRIPTION
People use cookiecutter-django to create new Django projects, and I think there's no point starting a project with Bootstrap 3 when Bootstrap 4 will be ready soon. This makes it easier for them to upgrade to Bootstrap 4 final when it comes out.

The main changes here are the updated stylesheet and navbar HTML. 