### PR TITLE
Remove styles that already exist in Bootstrap 4 (or 3).

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/sass/project.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/sass/project.scss
@@ -8,24 +8,6 @@
   border-color: #d6e9c6;
 }
 
-.alert-info {
-  color: #3a87ad;
-  background-color: #d9edf7;
-  border-color: #bce8f1;
-}
-
-.alert-success {
-  color: #468847;
-  background-color: #dff0d8;
-  border-color: #d6e9c6;
-}
-
-.alert-warning {
-  color: black;
-  background-color: orange;
-  border-color: #d6e9c6;
-}
-
 .alert-error {
   color: #b94a48;
   background-color: #f2dede;


### PR DESCRIPTION
We shouldn't have identical styles that duplicate what's already in Bootstrap.

Here's how the alerts look with these styles removed. 

![screen shot 2015-09-13 at 8 58 45 am](https://cloud.githubusercontent.com/assets/74739/9837499/ca9504a6-59f5-11e5-9964-d79cab116589.png)

They look exactly the same as before.