### PR TITLE
Updated hitch django_version

### DIFF
--- a/{{cookiecutter.repo_name}}/tests/settings.yml
+++ b/{{cookiecutter.repo_name}}/tests/settings.yml
@@ -1,6 +1,6 @@
 postgres_version: 9.3.9
 redis_version: 2.8.4
-django_version: 1.8.3
+django_version: 1.8.4
 celery_version: 3.1.18
 pause_on_success: false
 pause_on_failure: true


### PR DESCRIPTION
Now matches the installed version of Django via the requirements files.  

Part of Issues #339 