### PR TITLE
Remove commented-out flake8 ignore rule.

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -1,4 +1,3 @@
 [flake8]
-#ignore = E265
 max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules


### PR DESCRIPTION
Would it be okay to remove this commented-out line from our flake8 config?
Or is it there for a reason?