### PR TITLE
Fixed reStructuredText (RST) format

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -64,6 +64,7 @@ This can take a while, especially the first time you run this particular command
 on your development system.
 
 ::
+
     $ docker-compose build
 
 Boot the System


### PR DESCRIPTION
The lack of a space between the '::' tag and the text did that the block around the code didn't appear.