### PR TITLE
String view arguments to url() is deprecated in django 1.9

### DIFF
--- a/{{cookiecutter.repo_name}}/config/urls.py
+++ b/{{cookiecutter.repo_name}}/config/urls.py
@@ -6,6 +6,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
+from django.views import defaults as default_views
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='pages/home.html'), name="home"),
@@ -27,8 +28,8 @@ if settings.DEBUG:
     # This allows the error pages to be debugged during development, just visit
     # these url in browser to see how these error pages look like.
     urlpatterns += [
-        url(r'^400/$', 'django.views.defaults.bad_request'),
-        url(r'^403/$', 'django.views.defaults.permission_denied'),
-        url(r'^404/$', 'django.views.defaults.page_not_found'),
-        url(r'^500/$', 'django.views.defaults.server_error'),
+        url(r'^400/$', default_views.bad_request),
+        url(r'^403/$', default_views.permission_denied),
+        url(r'^404/$', default_views.page_not_found),
+        url(r'^500/$', default_views.server_error),
     ]


### PR DESCRIPTION
Hello. I tried django 1.9 and found
```bash
config/urls.py:29: 
RemovedInDjango110Warning: Support for string view arguments to 
url() is deprecated and will be removed in Django 1.10 
(got django.views.defaults.bad_request). Pass the callable instead.
  url(r'^400/$', 'django.views.defaults.bad_request'),
```