### PR TITLE
Add newrelic for monitoring.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ Features
 * Pre configured Celery_ (optional)
 * Integration with Maildump_ for local email testing (optional)
 * Integration with Sentry_ for error logging (optional)
+* Integration with NewRelic_ for performance monitoring (optional)
 * Docker support using docker-compose_ for dev and prod
 * Procfile_ for deploying to Heroku
 
@@ -53,6 +54,7 @@ Features
 .. _Celery: http://www.celeryproject.org/
 .. _Maildump: https://github.com/ThiefMaster/maildump
 .. _Sentry: https://getsentry.com
+.. _NewRelic: https://newrelic.com
 .. _docker-compose: https://www.github.com/docker/compose
 
 
@@ -105,6 +107,7 @@ It prompts you for questions. Answer them::
     use_celery [n]: y
     use_maildump [n]: n
     use_sentry [n]: y
+    use_newrelic [n]: y
     windows [n]: n
     use_python2 [n]: y
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,6 +13,7 @@
     "use_celery": "n",
     "use_maildump": "n",
     "use_sentry": "n",
+    "use_newrelic": "n",
     "windows": "n",
     "use_python2": "n"
 }

--- a/{{cookiecutter.repo_name}}/app.json
+++ b/{{cookiecutter.repo_name}}/app.json
@@ -21,7 +21,8 @@
     "DJANGO_AWS_STORAGE_BUCKET_NAME": "",
     "DJANGO_MAILGUN_SERVER_NAME": "",
     "DJANGO_MAILGUN_API_KEY": ""{% if cookiecutter.use_sentry == "y" -%},
-    "DJANGO_SENTRY_DSN": ""{%- endif %}
+    "DJANGO_SENTRY_DSN": ""{%- endif %}{% if cookiecutter.use_newrelic == "y -%"},
+    "NEW_RELIC_LICENSE_KEY": ""{%- endif %}
   },
   "scripts": {
     "postdeploy": "python manage.py migrate"

--- a/{{cookiecutter.repo_name}}/app.json
+++ b/{{cookiecutter.repo_name}}/app.json
@@ -20,9 +20,11 @@
     "DJANGO_AWS_SECRET_ACCESS_KEY": "",
     "DJANGO_AWS_STORAGE_BUCKET_NAME": "",
     "DJANGO_MAILGUN_SERVER_NAME": "",
+    {% if cookiecutter.use_newrelic == "y" -%}
+    "NEW_RELIC_LICENSE_KEY": "",
+    {%- endif %}
     "DJANGO_MAILGUN_API_KEY": ""{% if cookiecutter.use_sentry == "y" -%},
-    "DJANGO_SENTRY_DSN": ""{%- endif %}{% if cookiecutter.use_newrelic == "y -%"},
-    "NEW_RELIC_LICENSE_KEY": ""{%- endif %}
+    "DJANGO_SENTRY_DSN": ""{%- endif %} 
   },
   "scripts": {
     "postdeploy": "python manage.py migrate"

--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -130,11 +130,9 @@ MAILGUN_ACCESS_KEY = env('DJANGO_MAILGUN_API_KEY')
 MAILGUN_SERVER_NAME = env('DJANGO_MAILGUN_SERVER_NAME')
 EMAIL_SUBJECT_PREFIX = env("DJANGO_EMAIL_SUBJECT_PREFIX", default='[{{cookiecutter.project_name}}] ')
 SERVER_EMAIL = env('DJANGO_SERVER_EMAIL', default=DEFAULT_FROM_EMAIL)
-
 {% if cookiecutter.use_newrelic == 'y'-%}
 NEW_RELIC_LICENSE_KEY = env('NEW_RELIC_LICENSE_KEY')
 {%- endif %}
-
 
 # TEMPLATE CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -131,6 +131,11 @@ MAILGUN_SERVER_NAME = env('DJANGO_MAILGUN_SERVER_NAME')
 EMAIL_SUBJECT_PREFIX = env("DJANGO_EMAIL_SUBJECT_PREFIX", default='[{{cookiecutter.project_name}}] ')
 SERVER_EMAIL = env('DJANGO_SERVER_EMAIL', default=DEFAULT_FROM_EMAIL)
 
+{% if cookiecutter.use_newrelic == 'y'-%}
+NEW_RELIC_LICENSE_KEY = env('NEW_RELIC_LICENSE_KEY')
+{%- endif %}
+
+
 # TEMPLATE CONFIGURATION
 # ------------------------------------------------------------------------------
 # See:

--- a/{{cookiecutter.repo_name}}/config/wsgi.py
+++ b/{{cookiecutter.repo_name}}/config/wsgi.py
@@ -53,7 +53,6 @@ if os.environ.get("DJANGO_SETTINGS_MODULE") == "config.settings.production":
 if os.environ.get("DJANGO_SETTINGS_MODULE") == "config.settings.production":
     application = newrelic.agent.WSGIApplicationWrapper(application)
 {%- endif %}
-
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)

--- a/{{cookiecutter.repo_name}}/config/wsgi.py
+++ b/{{cookiecutter.repo_name}}/config/wsgi.py
@@ -15,6 +15,11 @@ framework.
 """
 import os
 
+{% if cookiecutter.use_newrelic == "y" -%}
+if os.environ.get("DJANGO_SETTINGS_MODULE") == "config.settings.production":
+    import newrelic.agent
+    newrelic.agent.initialize()
+{%- endif %}
 from django.core.wsgi import get_wsgi_application
 {% if cookiecutter.use_whitenoise == 'y' -%}
 from whitenoise.django import DjangoWhiteNoise
@@ -43,6 +48,10 @@ application = DjangoWhiteNoise(application)
 {% if cookiecutter.use_sentry == "y" -%}
 if os.environ.get("DJANGO_SETTINGS_MODULE") == "config.settings.production":
     application = Sentry(application)
+{%- endif %}
+{% if cookiecutter.use_newrelic == "y" -%}
+if os.environ.get("DJANGO_SETTINGS_MODULE") == "config.settings.production":
+    application = newrelic.agent.WSGIApplicationWrapper(application)
 {%- endif %}
 
 # Apply WSGI middleware here.

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -24,3 +24,9 @@ django-mailgun==0.7.2
 # --------------------------
 raven
 {%- endif %}
+
+{% if cookiecutter.use_newrelic == "y" -%}
+# Newrelic agent for performance monitoring
+# -----------------------------------------
+newrelic
+{%- endif %}


### PR DESCRIPTION
Please use this PR as a starting point for addressing https://github.com/pydanny/cookiecutter-django/issues/353. 

I have not tested this since I don't have various credentials (AWS keys) required to setup a production instance of the generated app. 

This PR also doesn't add logging for the newrelic agent because the [logging setup for sentry](https://github.com/pydanny/cookiecutter-django/blob/master/%7B%7Bcookiecutter.repo_name%7D%7D/config/settings/production.py#L167) seems to override everything else, which will have to change.