### PR TITLE
Fixes #363 - Remove stray closing tags, fix navbar margin

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -31,7 +31,7 @@
 
   <body>
     
-    <div class="m-b-lg">
+    <div class="m-b">
       <nav class="navbar navbar-dark navbar-static-top bg-inverse">
         <div class="container">
          <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
@@ -42,17 +42,17 @@
           <!-- Collect the nav links, forms, and other content for toggling -->
           <div class="collapse navbar-toggleable-xs" id="bs-navbar-collapse-1">
             <nav class="nav navbar-nav">
-              <a class="nav-link nav-item" href="{% url 'home' %}">Home</a></li>
-              <a class="nav-link nav-item" href="{% url 'about' %}">About</a></li>
+              <a class="nav-link nav-item" href="{% url 'home' %}">Home</a>
+              <a class="nav-link nav-item" href="{% url 'about' %}">About</a>
             </nav>
         
             <nav class="nav navbar-nav pull-right">
               {% if request.user.is_authenticated %}
-                <a class="nav-link nav-item" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a></li>
-                <a class="nav-link nav-item" href="{% url 'account_logout' %}">{% trans "Logout" %}</a></li>
+                <a class="nav-link nav-item" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a>
+                <a class="nav-link nav-item" href="{% url 'account_logout' %}">{% trans "Logout" %}</a>
               {% else %}
-                <a class="nav-link nav-item" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a></li>
-                <a class="nav-link nav-item" href="{% url 'account_login' %}">{% trans "Log In" %}</a></li>
+                <a class="nav-link nav-item" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a>
+                <a class="nav-link nav-item" href="{% url 'account_login' %}">{% trans "Log In" %}</a>
               {% endif %}
             </nav>
           </div>


### PR DESCRIPTION
Removes stray </ul> tags that don't seem like they should be there. Reduces topbar bottom margin because it looked bad.