### PR TITLE
Adds Bootstrap 4 classes as crispy-forms override

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/bootstrap3/field.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/bootstrap3/field.html
@@ -1,0 +1,48 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    {% if field|is_checkbox %}
+        <div class="form-group row">
+        {% if label_class %}
+            <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
+        {% endif %}
+    {% endif %}
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group row{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+        {% if field.label and not field|is_checkbox and form_show_labels %}
+            <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        {% if field|is_checkboxselectmultiple %}
+            {% include 'bootstrap3/layout/checkboxselectmultiple.html' %}
+        {% endif %}
+
+        {% if field|is_radioselect %}
+            {% include 'bootstrap3/layout/radioselect.html' %}
+        {% endif %}
+
+        {% if not field|is_checkboxselectmultiple and not field|is_radioselect %}
+            {% if field|is_checkbox and form_show_labels %}
+                <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
+                    {% crispy_field field %}
+                    {{ field.label|safe }}
+                    {% include 'bootstrap3/layout/help_text_and_errors.html' %}
+                </label>
+            {% else %}
+                <div class="controls {{ field_class }}">
+                    {% crispy_field field %}
+                    {% include 'bootstrap3/layout/help_text_and_errors.html' %}
+                </div>
+            {% endif %}
+        {% endif %}
+    </{% if tag %}{{ tag }}{% else %}div{% endif %}>
+    {% if field|is_checkbox %}
+        {% if label_class %}
+            </div>
+        {% endif %}
+        </div>
+    {% endif %}
+{% endif %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/bootstrap3/field.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/bootstrap3/field.html
@@ -1,4 +1,4 @@
-{% load crispy_forms_field %}
+{% raw %}{% load crispy_forms_field %}
 
 {% if field.is_hidden %}
     {{ field }}
@@ -45,4 +45,4 @@
         {% endif %}
         </div>
     {% endif %}
-{% endif %}
+{% endif %}{% endraw %}


### PR DESCRIPTION
While we're waiting on a crispy-forms update I added a template override for that library's bootstrap3 implementation. What it does is apply the missing classes to the form. Addresses #365.

I've flagged the relevant crispy-forms issues so when (maraujop/django-crispy-forms#524), so when this is addressed in that package, we can remove this template.