### PR TITLE
Fix gevent requirement for Python 3

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -14,8 +14,13 @@ django-debug-toolbar==1.4
 ipdb==0.8.1
 
 {% if cookiecutter.use_maildump == "y" -%}
-# Required by maildump. Need to pin dependency to gevent beta to be Python 3-compatible.
+# Required by maildump.
+{% if cookiecutter.use_python2 == 'n' -%}
+# Need to pin dependency to gevent beta to be Python 3-compatible.
+gevent==1.1b6
+{% else -%}
 gevent==1.0.2
+{% endif -%}
 # Enables better email testing
 maildump==0.5.1
 {%- endif %}


### PR DESCRIPTION
gevent==1.0.2 isn't compatible with Python 3. 
gevent==1.1b6 is a beta version but it is compatible. 
I used a conditional to replace gevent==1.0.2 with gevent==1.1b6 if use_python2 = 'n'.