### PR TITLE
changed ADMIN_URL to DJANGO_ADMIN_URL in env.example

### DIFF
--- a/{{cookiecutter.repo_name}}/env.example
+++ b/{{cookiecutter.repo_name}}/env.example
@@ -1,7 +1,7 @@
 POSTGRES_PASSWORD=mysecretpass
 POSTGRES_USER=postgresuser
 
-ADMIN_URL=
+DJANGO_ADMIN_URL=
 DJANGO_SETTINGS_MODULE=config.settings.production
 DJANGO_SECRET_KEY=CHANGEME!!!
 DJANGO_ALLOWED_HOSTS=.{{ cookiecutter.domain_name }}


### PR DESCRIPTION
DJANGO_ADMIN_URL is an expected environment variable which is used to set ADMIN_URL.  The current env.example fails due to the missing DJANGO_ADMIN_URL variable.