### PR TITLE
Replace Maildump with MailHog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2015-11-17]
 ### Added
 - initial configuration to support opbeat (@burhan)
+### Removed
+- Took *.pyc out of .gitignore, because it's already covered by *.py[cod] (@audreyr)
 
 ## [2015-11-16]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All enhancements and patches to cookiecutter-django will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2015-11-17]
+### Added
+- initial configuration to support opbeat (@burhan)
+
 ## [2015-11-12]
 ### Changed
 - Update version of django-allauth (@yunti)

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Optional Integrations
 
 * Serve static files from Amazon S3 or Whitenoise_
 * Configuration for Celery_
-* Integration with Maildump_ for local email testing
+* Integration with MailHog_ for local email testing
 * Integration with Sentry_ for error logging
 * Integration with NewRelic_ for performance monitoring
 * Integration with Opbeat_ for performance monitoring
@@ -59,7 +59,7 @@ Optional Integrations
 .. _Mailgun: https://mailgun.com/
 .. _Whitenoise: https://whitenoise.readthedocs.org/
 .. _Celery: http://www.celeryproject.org/
-.. _Maildump: https://github.com/ThiefMaster/maildump
+.. _MailHog: https://github.com/mailhog/MailHog
 .. _Sentry: https://getsentry.com
 .. _NewRelic: https://newrelic.com
 .. _docker-compose: https://www.github.com/docker/compose
@@ -115,7 +115,7 @@ It prompts you for questions. Answer them::
     year [2015]:
     use_whitenoise [y]: n
     use_celery [n]: y
-    use_maildump [n]: n
+    use_mailhog [n]: n
     use_sentry [n]: y
     use_newrelic [n]: y
     use_obpeat [n]: y

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "year": "{{ cookiecutter.now[:4] }}",
     "use_whitenoise": "y",
     "use_celery": "n",
-    "use_maildump": "n",
+    "use_mailhog": "n",
     "use_sentry": "n",
     "use_newrelic": "n",
     "use_opbeat": "n",

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -31,9 +31,16 @@ django-allauth sends an email to verify users (and superusers) after signup and 
 
 .. _configure your email backend: http://docs.djangoproject.com/en/1.8/topics/email/#smtp-backend
 
-In development you can (optionally) use Maildump_ for email testing. Or alternatively simply output emails to the console via: ``EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'``
+In development you can (optionally) use MailHog_ for email testing. MailHog is built with Go so there are no dependencies. To use MailHog::
 
-.. _Maildump: https://github.com/ThiefMaster/maildump
+1. `Download the latest release`_ for your operating system
+2. Rename the executable to ``mailhog`` and copy it to the root of your project directory
+3. Make sure it is executable (e.g. ``chmod +x mailhog``)
+
+.. _Mailhog: https://github.com/mailhog/MailHog/
+.. _Download the latest release: https://github.com/mailhog/MailHog/releases
+
+Alternatively simply output emails to the console via: ``EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'``
 
 In production basic email configuration is setup to send emails with Mailgun_
 

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -34,10 +34,10 @@ use_celery [n]
     Whether to use Celery_. This gives you the ability to use distributed task
     queues in your project.
 
-use_maildump [n]
-    Whether to use Maildump_. Maildump is a tool that simulates email receiving
-    for development purposes. It runs a super simple SMTP server which catches
-    any message sent to it. Then messages are displayed in a web interface.
+use_mailhog [n]
+    Whether to use MailHog_. MailHog is a tool that simulates email receiving
+    for development purposes. It runs a simple SMTP server which catches
+    any message sent to it. Messages are displayed in a web interface which runs at ``http://localhost:8025/`` You need to download the MailHog executable for your operating system, see the 'Developing Locally' docs for instructions.
 
 use_sentry [n]
     Whether to use Sentry_ to log errors from your project.
@@ -51,5 +51,5 @@ use_python2 [n]
 
 .. _WhiteNoise: https://github.com/evansd/whitenoise
 .. _Celery: https://github.com/celery/celery
-.. _Maildump: https://github.com/ThiefMaster/maildump
+.. _MailHog: https://github.com/mailhog/MailHog
 .. _Sentry: https://github.com/getsentry/sentry

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -62,7 +62,7 @@ def test_default_configuration(cookies, context):
     check_paths(paths)
 
 
-@pytest.fixture(params=['use_maildump', 'use_celery', 'windows'])
+@pytest.fixture(params=['use_mailhog', 'use_celery', 'windows'])
 def feature_context(request, context):
     context.update({request.param: 'y'})
     return context

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -21,7 +21,6 @@ sftp-config.json
 
 # Basics
 *.py[cod]
-*.pyc
 __pycache__
 
 # Logs

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -60,3 +60,6 @@ node_modules/
 
 # Hitch directory
 tests/.hitch
+
+# MailHog binary
+mailhog

--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -22,7 +22,6 @@ module.exports = function (grunt) {
       images: this.app + '/static/images',
       js: this.app + '/static/js',
       manageScript: 'manage.py',
-      {% if cookiecutter.use_maildump=="y" -%}mailserverpid: 'mailserver.pid',{%- endif %}
     }
   };
 
@@ -79,7 +78,7 @@ module.exports = function (grunt) {
           },
       }
     },
-    
+
     //see https://github.com/nDmitry/grunt-postcss
     postcss: {
       options: {
@@ -113,16 +112,16 @@ module.exports = function (grunt) {
       runDjango: {
         cmd: 'python <%= paths.manageScript %> runserver'
       },
-      {% if cookiecutter.use_maildump == "y" -%}runMailDump: {
-        cmd: 'maildump -p <%= paths.mailserverpid %>'
-      },
-      stopMailDump: {
-        cmd: 'maildump -p <%= paths.mailserverpid %> --stop'
+      {% if cookiecutter.use_mailhog == "y" -%}runMailHog: {
+        cmd: './mailhog'
       },{%- endif %}
     }
   });
 
   grunt.registerTask('serve', [
+    {% if cookiecutter.use_mailhog == "y" -%}
+    'bgShell:runMailHog',
+    {%- endif %}
     'bgShell:runDjango',
     'watch'
   ]);
@@ -135,12 +134,5 @@ module.exports = function (grunt) {
   grunt.registerTask('default', [
     'build'
   ]);
-  {% if cookiecutter.use_maildump == "y" -%}
-  grunt.registerTask('start-email-server', [
-      'bgShell:runMailDump'
-  ]);
 
-  grunt.registerTask('stop-email-server', [
-      'bgShell:stopMailDump'
-  ]);{%- endif %}
 };

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -61,28 +61,25 @@ Please note: For Celerys import magic to work, it is important *where* the celer
 
 {% endif %}
 
-{% if cookiecutter.use_maildump == "y" %}
+{% if cookiecutter.use_mailhog == "y" %}
 
 Email Server
 ^^^^^^^^^^^^
 
-In development, it is often nice to be able to see emails that are being sent from your application. For this purpose,
-a Grunt task exists to start an instance of `maildump`_ which is a local SMTP server with an online interface.
+In development, it is often nice to be able to see emails that are being sent from your application. If you choose to use `MailHog`_ when generating the project a local SMTP server with a web interface will be available.
 
-.. _maildump: https://github.com/ThiefMaster/maildump
+.. _mailhog: https://github.com/mailhog/MailHog
 
-Make sure you have nodejs installed, and then type the following::
+To start the service, make sure you have nodejs installed, and then type the following::
 
-    $ grunt start-email-server
+    $ npm install
+    $ grunt serve
 
-This will start an email server. The project is setup to deliver to the email server by default. To view messages
-that are sent by your application, open your browser to http://127.0.0.1:1080
+(After the first run you only need to type ``grunt serve``) This will start an email server that listens on ``127.0.0.1:1025`` in addition to starting your Django project and a watch task for live reload.
 
-To stop the email server::
+To view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
 
-    $ grunt stop-email-server
-
-The email server listens on 127.0.0.1:1025
+The email server will exit when you exit the Grunt task on the CLI with Ctrl+C.
 
 {% endif %}
 

--- a/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -25,7 +25,7 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default='CHANGEME!!!')
 # ------------------------------------------------------------------------------
 EMAIL_HOST = 'localhost'
 EMAIL_PORT = 1025
-{%if cookiecutter.use_maildump == "n" -%}
+{%if cookiecutter.use_mailhog == "n" -%}
 EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',
                     default='django.core.mail.backends.console.EmailBackend')
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -13,15 +13,3 @@ django-debug-toolbar==1.4
 
 # improved REPL
 ipdb==0.8.1
-
-{% if cookiecutter.use_maildump == "y" -%}
-# Required by maildump.
-{% if cookiecutter.use_python2 == 'n' -%}
-# Need to pin dependency to gevent beta to be Python 3-compatible.
-gevent==1.1b6
-{% else -%}
-gevent==1.0.2
-{% endif -%}
-# Enables better email testing
-maildump==0.5.1
-{%- endif %}


### PR DESCRIPTION
Since Maildump is not compatible with Python 3, I've replaced it with [MailHog](https://github.com/mailhog/MailHog).

MailHog is written in Go so the binary has no dependencies and releases are available for most platforms.

I've tested this and it works well. I've also updated the docs and readme files where relevant.