### PR TITLE
initial configuration to support opbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All enhancements and patches to cookiecutter-django will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2015-11-16]
+### Changed
+- Cleanup of main README (@burhan)
+
+## [2015-11-15]
+### Added
+- Added `UserFactory` for users.User tests (@ad-m)
+
 ## [2015-11-12]
 ### Changed
 - Update version of django-allauth (@yunti)

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Optional Integrations
 * Integration with Maildump_ for local email testing
 * Integration with Sentry_ for error logging
 * Integration with NewRelic_ for performance monitoring
+* Integration with Opbeat_ for performance monitoring
 
 .. _alpha: http://blog.getbootstrap.com/2015/08/19/bootstrap-4-alpha/
 .. _Hitch: https://github.com/hitchtest/hitchtest
@@ -62,6 +63,7 @@ Optional Integrations
 .. _Sentry: https://getsentry.com
 .. _NewRelic: https://newrelic.com
 .. _docker-compose: https://www.github.com/docker/compose
+.. _Opbeat: https://opbeat.com/
 
 
 Constraints
@@ -116,6 +118,7 @@ It prompts you for questions. Answer them::
     use_maildump [n]: n
     use_sentry [n]: y
     use_newrelic [n]: y
+    use_obpeat [n]: y
     windows [n]: n
     use_python2 [n]: y
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,7 @@
     "use_maildump": "n",
     "use_sentry": "n",
     "use_newrelic": "n",
+    "use_opbeat": "n",
     "windows": "n",
     "use_python2": "n"
 }

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -41,4 +41,7 @@ DJANGO_SENTRY_LOG_LEVEL                 SENTRY_LOG_LEVEL            n/a         
 DJANGO_MAILGUN_API_KEY                  MAILGUN_ACCESS_KEY          n/a                                            raises error
 DJANGO_MAILGUN_SERVER_NAME              MAILGUN_SERVER_NAME         n/a                                            raises error
 NEW_RELIC_LICENSE_KEY                   NEW_RELIC_LICENSE_KEY       n/a                                            raises error
+DJANGO_OPBEAT_APP_ID                    OPBEAT['APP_ID']            n/a                                            raises error
+DJANGO_OPBEAT_SECRET_TOKEN              OPBEAT['SECRET_TOKEN']      n/a                                            raises error
+DJANGO_OPBEAT_ORGANIZATION_ID           OPBEAT['ORGANIZATION_ID']   n/a                                            raises error
 ======================================= =========================== ============================================== ======================================================================

--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -9,6 +9,9 @@ Production Configurations
 {% if cookiecutter.use_sentry == "y" %}
 - Use sentry for error logging
 {% endif %}
+{% if cookiecutter.use_opbeat == "y" %}
+- Use opbeat for error reporting
+{% endif %}
 '''
 from __future__ import absolute_import, unicode_literals
 
@@ -17,6 +20,7 @@ from django.utils import six
 {% if cookiecutter.use_sentry == "y" %}
 import logging
 {% endif %}
+
 
 from .common import *  # noqa
 
@@ -52,7 +56,19 @@ MIDDLEWARE_CLASSES = SECURITY_MIDDLEWARE + \
 MIDDLEWARE_CLASSES = SECURITY_MIDDLEWARE + MIDDLEWARE_CLASSES
 
 {%- endif %}
-
+{% if cookiecutter.use_opbeat == "y" -%}
+# opbeat integration
+# See https://opbeat.com/languages/django/
+INSTALLED_APPS += ('opbeat.contrib.django',)
+OPBEAT = {
+    'ORGANIZATION_ID': env('DJANGO_OPBEAT_ORGANIZATION_ID'),
+    'APP_ID': env('DJANGO_OPBEAT_APP_ID'),
+    'SECRET_TOKEN': env('DJANGO_OPBEAT_SECRET_TOKEN')
+}
+MIDDLEWARE_CLASSES += (
+    'opbeat.contrib.django.middleware.OpbeatAPMMiddleware',
+)
+{%- endif %}
 # set this to 60 seconds and then to 518400 when you can prove it works
 SECURE_HSTS_SECONDS = 60
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool(

--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -65,9 +65,9 @@ OPBEAT = {
     'APP_ID': env('DJANGO_OPBEAT_APP_ID'),
     'SECRET_TOKEN': env('DJANGO_OPBEAT_SECRET_TOKEN')
 }
-MIDDLEWARE_CLASSES += (
+MIDDLEWARE_CLASSES = (
     'opbeat.contrib.django.middleware.OpbeatAPMMiddleware',
-)
+) + MIDDLEWARE_CLASSES
 {%- endif %}
 # set this to 60 seconds and then to 518400 when you can prove it works
 SECURE_HSTS_SECONDS = 60

--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -21,7 +21,6 @@ from django.utils import six
 import logging
 {% endif %}
 
-
 from .common import *  # noqa
 
 # SECRET CONFIGURATION

--- a/{{cookiecutter.repo_name}}/env.example
+++ b/{{cookiecutter.repo_name}}/env.example
@@ -18,3 +18,8 @@ DJANGO_SENTRY_DSN=
 {% if cookiecutter.use_newrelic == 'y' -%}
 NEW_RELIC_LICENSE_KEY
 {% endif %}
+{% if cookiecutter.use_opbeat == 'y' -%}
+DJANGO_OPBEAT_ORGANIZATION_ID
+DJANGO_OPBEAT_APP_ID
+DJANGO_OPBEAT_SECRET_TOKEN
+{% endif %}

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -37,3 +37,9 @@ raven
 # -----------------------------------------
 newrelic
 {%- endif %}
+
+{% if cookiecutter.use_opbeat == "y" -%}
+# Opbeat agent for performance monitoring
+# -----------------------------------------
+opbeat
+{%- endif %}


### PR DESCRIPTION
I would like to propose including [opbeat](https://opbeat.com/languages/django/) as an alternative to newrelic for performance monitoring.

I personally find them a bit easier to get setup; and their free tier is also a lot more accommodating.

I am not against keeping both (yaay for choice!) if someone would like to test both options and then decide which one they want to keep.

The initial commit does not add logging configuration; which is still left up to sentry.