### PR TITLE
Use python 3.5 on Heroku/Travis

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 language: python
 python:
 {% if cookiecutter.use_python2 == 'n' -%}
-  - "3.4"
+  - "3.5"
 {% else %}
   - "2.7"
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/runtime.txt
+++ b/{{cookiecutter.repo_name}}/runtime.txt
@@ -1,3 +1,3 @@
 {% if cookiecutter.use_python2 == 'n' -%}
-python-3.4.3
+python-3.5.0
 {%- endif %}


### PR DESCRIPTION
This PR tells `Heroku`/`Travis` to use python `3.5`.