### PR TITLE
update requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All enhancements and patches to cookiecutter-django will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2015-11-24]
+### Changed
+- Update version of Django, coverage and click (@luzfcb)
+
 ## [2015-11-23]
 ### Changed
 - Update AngularJS version to 1.4.8 (@luzfcb)

--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -1,5 +1,5 @@
 # Bleeding edge Django
-django==1.8.6
+django==1.8.7
 
 # Configuration
 django-environ==0.4.0

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -1,6 +1,6 @@
 # Local development dependencies go here
 -r base.txt
-coverage==4.0.2
+coverage==4.0.3
 django_coverage_plugin==1.1
 Sphinx
 django-extensions==1.5.9

--- a/{{cookiecutter.repo_name}}/requirements/test.txt
+++ b/{{cookiecutter.repo_name}}/requirements/test.txt
@@ -7,7 +7,7 @@
 psycopg2==2.6.1
 {%- endif %}
 
-coverage==4.0.2
+coverage==4.0.3
 django_coverage_plugin==1.1
 flake8==2.5.0
 django-test-plus==1.0.11

--- a/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
+++ b/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
@@ -1,4 +1,4 @@
-click==5.1
+click==6.0
 colorama==0.3.3
 decorator==4.0.4
 docopt==0.6.2


### PR DESCRIPTION
Update:
* Django version from 1.8.6 to 1.8.7 (is a [security release](https://www.djangoproject.com/weblog/2015/nov/24/security-releases-issued/))
* coverage from 4.0.2 to 4.0.3
* click from 5.1 to 6.0