### PR TITLE
[IMP] Allow enable or disable user registration using ACCOUNT_ALLOW_REGISTRATION setting.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -69,6 +69,7 @@ Code Contributors
 * Jan Van Bruggen / @jvanbrug
 * Jon Miller / @jondelmil
 * Thomas Korrison / @failsafe86
+* David Díaz / @DavidDiazPinto *
 
 \* Possesses commit rights
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -45,3 +45,10 @@ DJANGO_OPBEAT_APP_ID                    OPBEAT['APP_ID']            n/a         
 DJANGO_OPBEAT_SECRET_TOKEN              OPBEAT['SECRET_TOKEN']      n/a                                            raises error
 DJANGO_OPBEAT_ORGANIZATION_ID           OPBEAT['ORGANIZATION_ID']   n/a                                            raises error
 ======================================= =========================== ============================================== ======================================================================
+
+--------------
+Other Settings
+--------------
+
+ACCOUNT_ALLOW_REGISTRATION (=True)
+    Allow enable or disable user registration through `django-allauth` without disabling other characteristics like authentication and account management.

--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -211,6 +211,9 @@ AUTHENTICATION_BACKENDS = (
 ACCOUNT_AUTHENTICATION_METHOD = 'username'
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+ACCOUNT_ADAPTER = '{{cookiecutter.repo_name}}.users.adapter.AccountAdapter'
+SOCIALACCOUNT_ADAPTER = '{{cookiecutter.repo_name}}.users.adapter.SocialAccountAdapter'
+ACCOUNT_ALLOW_REGISTRATION = True
 
 # Custom user app defaults
 # Select the correct user model

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/users/adapter.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/users/adapter.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from allauth.account.adapter import DefaultAccountAdapter
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+
+
+class AccountAdapter(DefaultAccountAdapter):
+    def is_open_for_signup(self, request):
+        return getattr(settings, 'ACCOUNT_ALLOW_REGISTRATION', True)
+
+
+class SocialAccountAdapter(DefaultSocialAccountAdapter):
+    def is_open_for_signup(self, request):
+        return getattr(settings, 'ACCOUNT_ALLOW_REGISTRATION', True)


### PR DESCRIPTION
The intention of this improvement is to allow enable and disable user registration through `django-allauth`, using `ACCOUNT_ALLOW_REGISTRATION` setting but without loosing other characteristics like authentication and account management.

Projects that may benefit from this improvement are those that do not require user registration at all  but need the authentication of current users through other methods like social networks, and other projects that needs temporary disable the registration process, for example, not-ready projects.
