### PR TITLE
SECRET_KEY gen to short

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -16,8 +16,8 @@ You can either push the 'deploy' button in your generated README.rst or run thes
     heroku addons:create heroku-redis:hobby-dev
     heroku addons:create mailgun
 
-    heroku config:set DJANGO_ADMIN_URL=`openssl rand -base64 32`
-    heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 32`
+    heroku config:set DJANGO_ADMIN_URL=`openssl rand -base64 64`
+    heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 64`
     heroku config:set DJANGO_SETTINGS_MODULE='config.settings.production'
     heroku config:set DJANGO_ALLOWED_HOSTS='.herokuapp.com'
 

--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -16,7 +16,7 @@ You can either push the 'deploy' button in your generated README.rst or run thes
     heroku addons:create heroku-redis:hobby-dev
     heroku addons:create mailgun
 
-    heroku config:set DJANGO_ADMIN_URL=`openssl rand -base64 64`
+    heroku config:set DJANGO_ADMIN_URL=`openssl rand -base64 32`
     heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 64`
     heroku config:set DJANGO_SETTINGS_MODULE='config.settings.production'
     heroku config:set DJANGO_ALLOWED_HOSTS='.herokuapp.com'


### PR DESCRIPTION
when `heroku run python manage.py check --deploy` is ran this error occurs
```
?: (security.W009) Your SECRET_KEY has less than 
 50 characters or less than 5 unique characters. 
```
Please generate a long and random `SECRET_KEY`, otherwise many of Django's security-critical features will be vulnerable to attack.

changing the num of ran to a larger number fixes this issue