### PR TITLE
Replace pull-right (broken) with pull-xs-right

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/css/project.css
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/css/project.css
@@ -24,7 +24,7 @@
     margin-left: 0;
   }
 
-  .nav.navbar-nav.pull-right {
+  .nav.navbar-nav.pull-xs-right {
     float: none !important;
   }
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/sass/project.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static/sass/project.scss
@@ -37,7 +37,7 @@ $red: #b94a48;
     margin-left: 0;
   }
 
-  .nav.navbar-nav.pull-right {
+  .nav.navbar-nav.pull-xs-right {
     float: none !important;
   }
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -35,7 +35,7 @@
       <nav class="navbar navbar-dark navbar-static-top bg-inverse">
         <div class="container">
           <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
-          <button type="button" class="navbar-toggler hidden-sm-up pull-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">
+          <button type="button" class="navbar-toggler hidden-sm-up pull-xs-right" data-toggle="collapse" data-target="#bs-navbar-collapse-1">
             &#9776;
           </button>
 
@@ -50,7 +50,7 @@
               </li>
             </ul>
 
-            <ul class="nav navbar-nav pull-right">
+            <ul class="nav navbar-nav pull-xs-right">
               {% if request.user.is_authenticated %}
                 <li class="nav-item">
                   <a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a>


### PR DESCRIPTION
twbs/bootstrap#18340 removed `.pull-left` and `.pull-right`
since they're redundant with `.pull-xs-left` and `.pull-xs-right`.

This solves the styling bug explained in
pydanny/cookiecutter-django#452.