### PR TITLE
Added a cdn link to Tether, which is a new requirement for Bootstrap 4

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -95,6 +95,9 @@
       <!-- Latest JQuery -->
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
 
+      <!-- Tether - a requirement for Bootstrap tooltips -->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.1.1/js/tether.min.js"></script>
+
       <!-- Latest compiled and minified JavaScript -->
       <script src="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/js/bootstrap.js"></script>
 


### PR DESCRIPTION
More information [here](http://v4-alpha.getbootstrap.com/components/tooltips/#overview). Looks like Tether is needed for proper positioning of Bootstrap tooltips. 