### PR TITLE
initial fixes for docker issue on windows 10

### DIFF
--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -17,7 +17,7 @@ RUN chown -R django /app
 COPY ./compose/django/gunicorn.sh /gunicorn.sh
 COPY ./compose/django/entrypoint.sh /entrypoint.sh
 RUN sed -i 's/\r//' /entrypoint.sh
-RUN set -i 's/\r//' /guincorn.sh
+RUN sed -i 's/\r//' /guincorn.sh
 RUN chmod +x /entrypoint.sh && chown django /entrypoint.sh
 RUN chmod +x /gunicorn.sh && chown django /gunicorn.sh
 

--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -16,7 +16,8 @@ RUN chown -R django /app
 
 COPY ./compose/django/gunicorn.sh /gunicorn.sh
 COPY ./compose/django/entrypoint.sh /entrypoint.sh
-
+RUN sed -i 's/\r//' /entrypoint.sh
+RUN set -i 's/\r//' /guincorn.sh
 RUN chmod +x /entrypoint.sh && chown django /entrypoint.sh
 RUN chmod +x /gunicorn.sh && chown django /gunicorn.sh
 

--- a/{{cookiecutter.repo_name}}/Dockerfile-dev
+++ b/{{cookiecutter.repo_name}}/Dockerfile-dev
@@ -10,6 +10,7 @@ COPY ./requirements /requirements
 RUN pip install -r /requirements/local.txt
 
 COPY ./compose/django/entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r//' /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 WORKDIR /app


### PR DESCRIPTION
Please test; I have done the least destructive fix - the previous fixes with `.gitignore` mungering were not reliable during testing.

I also realized that the `.editorconfig` is also forcing line endings to `LR` which will help if the editor being used supports editorconfig (most popular ones do via plugins).