### PR TITLE
Adds celerybeat db to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ my_test_project/*
 # Generated when running py.test for the cookiecutter-django generation tests
 .cache/
 
+# Generated when running celery beat
+celerybeat-schedule.db
+
 # Unit test / coverage reports
 .coverage
 .tox


### PR DESCRIPTION
When testing "production mode" locally, celery of course generates it's task scheduling database for `celery beat`. It doesn't really make much sense to track this with any VCS :)

Might also be nice to add this to #460 ?