### PR TITLE
Testing Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: false
+sudo: required
+
+services:
+  - docker
+
 language: python
 python: 3.5
 env:
@@ -8,7 +12,9 @@ env:
     - TOX_ENV=py34
     - TOX_ENV=py35
 
-script: tox -e $TOX_ENV
+script:
+    - tox -e $TOX_ENV
+    - sh tests/test_docker.sh
 
 install:
     - pip install tox

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# this is a very simple script that tests the docker configuration for cookiecutter-django
+# it is meant to be run from the root directory of the repository, eg:
+# sh tests/test_docker.sh
+
+# install test requirements
+pip install -r requirements.txt
+
+# create a cache directory
+mkdir -p .cache/docker
+cd .cache/docker
+
+# create the project using the default settings in cookiecutter.json
+cookiecutter ../../ --no-input --overwrite-if-exists
+cd project_name
+
+# run the project's tests
+docker-compose -f dev.yml run django python manage.py test


### PR DESCRIPTION
This PR adds a simple docker test that makes sure `python manage.py test` runs successfully using the development configuration in `dev.yml` with default values.

It comes with it's own shell script in `tests/` and can be run locally using `sh tests/test_docker.sh`.

I'd like to build upon this in feature versions using the `hitch` tests and possibly a lot more configurations, but I think that it's a good start for now.