### PR TITLE
Fix for issue #389 (and related issues). 

### DIFF
--- a/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
+++ b/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
@@ -35,5 +35,5 @@ six==1.10.0
 tblib==1.2.0
 tornado==4.3
 traitlets==4.1.0
-unixpackage==0.4.0
+unixpackage==0.4.1
 xeger==0.3

--- a/{{cookiecutter.repo_name}}/tests/system.packages
+++ b/{{cookiecutter.repo_name}}/tests/system.packages
@@ -2,10 +2,10 @@ firefox
 libpq-dev
 llvm
 graphviz-dev
-libtiff4-dev
+libtiff-dev
 libjpeg8-dev
 libfreetype6-dev
-liblcms1-dev
+liblcms-dev
 libwebp-dev
 zlib1g-dev
 gettext


### PR DESCRIPTION
For when different linux distributions have different equivalent packages (i.e. libtiff5-dev / libcms2-dev for ubuntu wily and libtiff4-dev / libcms1-dev for ubuntu trusty). The latest version of unixpackage ensures that the correct one is installed for the distribution the user is on.

Related to isssue #389 