### PR TITLE
Upgraded hitchreqs.txt 

### DIFF
--- a/{{cookiecutter.repo_name}}/tests/all.settings
+++ b/{{cookiecutter.repo_name}}/tests/all.settings
@@ -13,7 +13,7 @@ environment_variables:
   DJANGO_EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
 window_size:
   width: 1024
-  height: 768
+  height: 600
 python_version: {% if cookiecutter.use_python2 == 'n' %}3.5.0{% else %}2.7.10{% endif %}
 environment:
   - approved_platforms:

--- a/{{cookiecutter.repo_name}}/tests/engine.py
+++ b/{{cookiecutter.repo_name}}/tests/engine.py
@@ -118,6 +118,7 @@ class ExecutionEngine(hitchtest.ExecutionEngine):
     def load_website(self):
         """Navigate to website in Firefox."""
         self.driver.get(self.services['Django'].url())
+        self.click("djHideToolBarButton")
 
     def fill_form(self, **kwargs):
         """Fill in a form with id=value."""

--- a/{{cookiecutter.repo_name}}/tests/engine.py
+++ b/{{cookiecutter.repo_name}}/tests/engine.py
@@ -102,7 +102,7 @@ class ExecutionEngine(hitchtest.ExecutionEngine):
         self.click_and_dont_wait_for_page_load = self.webapp.click_and_dont_wait_for_page_load
 
         # Configure selenium driver
-        self.driver.set_window_size(self.settings['window_size']['height'], self.settings['window_size']['width'])
+        self.driver.set_window_size(self.settings['window_size']['width'], self.settings['window_size']['height'])
         self.driver.set_window_position(0, 0)
         self.driver.implicitly_wait(2.0)
         self.driver.accept_next_alert = True

--- a/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
+++ b/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
@@ -1,6 +1,7 @@
+backports-abc==0.4
 click==6.2
 colorama==0.3.6
-decorator==4.0.7
+decorator==4.0.9
 docopt==0.6.2
 faketime==0.9.6.3
 hitchcron==0.2
@@ -16,6 +17,8 @@ humanize==0.5.1
 ipython==4.1.1
 ipython-genutils==0.1.0
 Jinja2==2.8
+jupyter-client==4.1.1
+jupyter-core==4.0.6
 MarkupSafe==0.23
 path.py==8.1.2
 patool==1.12
@@ -24,12 +27,13 @@ pickleshare==0.6
 psutil==3.4.2
 ptyprocess==0.5.1
 pykwalify==1.5.0
-python-build==0.2.12
+python-build==0.2.13
 python-dateutil==2.4.2
 pyuv==1.2.0
 PyYAML==3.11
+pyzmq==15.2.0
 requests==2.9.1
-selenium==2.51.1
+selenium==2.52.0
 simplegeneric==0.8.1
 six==1.10.0
 tblib==1.2.0

--- a/{{cookiecutter.repo_name}}/tests/register-and-log-in.test
+++ b/{{cookiecutter.repo_name}}/tests/register-and-log-in.test
@@ -1,7 +1,6 @@
 - name: Sign up and log in
   scenario:
     - Load website
-    - Click: djHideToolBarButton
     - Click: sign-up-link
     - Fill form:
         id_username: testuser

--- a/{{cookiecutter.repo_name}}/tests/tdd.settings
+++ b/{{cookiecutter.repo_name}}/tests/tdd.settings
@@ -6,3 +6,4 @@
 
 failfast: true
 pause_on_failure: true
+pause_on_success: true


### PR DESCRIPTION
Main fix:

* Note that decorator version 4.0.7 specified was removed from pypi. This breaks the set up process currently.

Also:

* Shrink the size of the firefox window a little (at the moment it goes off the edge of my screen). Width / Height were also the wrong way around (whoops).
* Remove the ugly "Click: djHideToolBarButton" step in the example 'register-and-log-in.test' and put it in the load_website step in engine instead.
* Pause on success as well when running tests in TDD mode. (--settings tdd.settings).