### PR TITLE
fix is_open_for_signup missing param

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/users/adapter.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/users/adapter.py
@@ -10,5 +10,5 @@ class AccountAdapter(DefaultAccountAdapter):
 
 
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
-    def is_open_for_signup(self, request):
+    def is_open_for_signup(self, request, sociallogin):
         return getattr(settings, 'ACCOUNT_ALLOW_REGISTRATION', True)


### PR DESCRIPTION
Add a missing param to SocialAccountAdapter.is_open_for_signup to fix [https://github.com/pydanny/cookiecutter-django/issues/479](https://github.com/pydanny/cookiecutter-django/issues/479)