### PR TITLE
fix minor typos in project README

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -64,7 +64,7 @@ To run a celery worker:
     cd {{cookiecutter.repo_name}}
     celery -A {{cookiecutter.repo_name}}.taskapp worker -l info
 
-Please note: For Celerys import magic to work, it is important *where* the celery commands are run. If you are in the same folder with *manage.py*, you should be right.
+Please note: For Celery's import magic to work, it is important *where* the celery commands are run. If you are in the same folder with *manage.py*, you should be right.
 
 {% endif %}
 
@@ -132,7 +132,7 @@ The testing framework runs Django, Celery (if enabled), Postgres, HitchSMTP (a m
 Deployment
 ----------
 
-We providing tools and instructions for deploying using Docker and Heroku.
+We provide tools and instructions for deploying using Docker and Heroku.
 
 Heroku
 ^^^^^^


### PR DESCRIPTION
Added an apostrophe and changed an awkward verb form in `{{cookiecutter.repo_name}}/README.rst`.