### PR TITLE
pylint-django gets "no-member" error: known issue

### DIFF
--- a/{{cookiecutter.repo_name}}/.pylintrc
+++ b/{{cookiecutter.repo_name}}/.pylintrc
@@ -9,3 +9,6 @@ disable=missing-docstring,invalid-name
 
 [DESIGN]
 max-parents=13
+
+[TYPECHECK]
+generated-members=REQUEST,acl_users,aq_parent,"[a-zA-Z]+_set{1,2}",save,delete


### PR DESCRIPTION
Suggested workaround
A known issue with pylint-django
https://github.com/landscapeio/pylint-django/issues/53

https://github.com/christianmlong/personal/commit/2939cb1d1a08bda225441e0b5326228fb757ee15
Tested on:
pylint==1.5.4
pylint-django==0.7.1