### PR TITLE
typos and cleanup

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -7,7 +7,7 @@ You can either push the 'deploy' button in your generated README.rst or run thes
 
 .. code-block:: bash
 
-    heroku create --buildpack https://github.com/heroku/heroku-buildpack-python
+    heroku create --buildpack heroku/python
 
     heroku addons:create heroku-postgresql:hobby-dev
     heroku pg:backups schedule --at '02:00 America/Los_Angeles' DATABASE_URL
@@ -16,10 +16,10 @@ You can either push the 'deploy' button in your generated README.rst or run thes
     heroku addons:create heroku-redis:hobby-dev
     heroku addons:create mailgun
 
-    heroku config:set DJANGO_ADMIN_URL=`openssl rand -base64 32`
     heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 64`
-    heroku config:set DJANGO_SETTINGS_MODULE='config.settings.production'
+    heroku config:set DJANGO_SETTINGS_MODULE='config.settings.local'                
     heroku config:set DJANGO_ALLOWED_HOSTS='.herokuapp.com'
+    heroku config:set DJANGO_ADMIN_URL=\^somelocation/
 
     heroku config:set DJANGO_AWS_ACCESS_KEY_ID=YOUR_AWS_ID_HERE
     heroku config:set DJANGO_AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY_HERE
@@ -27,9 +27,6 @@ You can either push the 'deploy' button in your generated README.rst or run thes
 
     heroku config:set DJANGO_MAILGUN_SERVER_NAME=YOUR_MALGUN_SERVER
     heroku config:set DJANGO_MAILGUN_API_KEY=YOUR_MAILGUN_API_KEY
-
-    heroku config:set PYTHONHASHSEED=random
-    heroku config:set DJANGO_ADMIN_URL=\^somelocation/ 
 
     git push heroku master
     heroku run python manage.py migrate


### PR DESCRIPTION
- changed the "heroku create" syntax to match what's used in the buildpack doc
- removed the first DJANGO_ADMIN_URL, it's probably a typo and it's overridden by the second def
- changed DJANGO_SETTINGS_MODULE to use local because that's more appropriate for an example and production is further down the road (given that, I would also remove DJANGO_ADMIN_URL since it has a [logical default for development](http://cookiecutter-django.readthedocs.org/en/latest/settings.html), but I left it intact)
- removed PYTHONHASHSEED since random is the default