### PR TITLE
Make sure that STATIC_URL != MEDIA_URL

### DIFF
--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -97,7 +97,6 @@ INSTALLED_APPS += ("gunicorn", )
 INSTALLED_APPS += (
     'storages',
 )
-DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 AWS_ACCESS_KEY_ID = env('DJANGO_AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = env('DJANGO_AWS_SECRET_ACCESS_KEY')
@@ -122,6 +121,12 @@ AWS_HEADERS = {
 {% if cookiecutter.use_whitenoise == 'y' -%}
 MEDIA_URL = 'https://s3.amazonaws.com/%s/' % AWS_STORAGE_BUCKET_NAME
 {% else %}
+#  See:http://stackoverflow.com/questions/10390244/
+from storages.backends.s3boto import S3BotoStorage
+StaticRootS3BotoStorage = lambda: S3BotoStorage(location='static')
+MediaRootS3BotoStorage = lambda: S3BotoStorage(location='media')
+DEFAULT_FILE_STORAGE = 'config.settings.production.MediaRootS3BotoStorage'
+
 MEDIA_URL = 'https://s3.amazonaws.com/%s/media/' % AWS_STORAGE_BUCKET_NAME
 {%- endif %}
 
@@ -130,8 +135,8 @@ MEDIA_URL = 'https://s3.amazonaws.com/%s/media/' % AWS_STORAGE_BUCKET_NAME
 {% if cookiecutter.use_whitenoise == 'y' -%}
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 {% else %}
-STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
 STATIC_URL = 'https://s3.amazonaws.com/%s/static/' % AWS_STORAGE_BUCKET_NAME
+STATICFILES_STORAGE = 'config.settings.production.StaticRootS3BotoStorage'
 
 # See: https://github.com/antonagestam/collectfast
 # For Django 1.7+, 'collectfast' should come before

--- a/{{cookiecutter.repo_name}}/config/settings/production.py
+++ b/{{cookiecutter.repo_name}}/config/settings/production.py
@@ -119,7 +119,11 @@ AWS_HEADERS = {
 
 # URL that handles the media served from MEDIA_ROOT, used for managing
 # stored files.
+{% if cookiecutter.use_whitenoise == 'y' -%}
 MEDIA_URL = 'https://s3.amazonaws.com/%s/' % AWS_STORAGE_BUCKET_NAME
+{% else %}
+MEDIA_URL = 'https://s3.amazonaws.com/%s/media/' % AWS_STORAGE_BUCKET_NAME
+{%- endif %}
 
 # Static Assets
 # ------------------------
@@ -127,7 +131,7 @@ MEDIA_URL = 'https://s3.amazonaws.com/%s/' % AWS_STORAGE_BUCKET_NAME
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 {% else %}
 STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
-STATIC_URL = MEDIA_URL
+STATIC_URL = 'https://s3.amazonaws.com/%s/static/' % AWS_STORAGE_BUCKET_NAME
 
 # See: https://github.com/antonagestam/collectfast
 # For Django 1.7+, 'collectfast' should come before


### PR DESCRIPTION
https://github.com/pydanny/cookiecutter-django/issues/254
This should ensure that STATIC_URL stays the same as it was if using whitenoise, but if whitenoise is not being used it will point to an specific folder inside S3. MEDIA_URL will change in this case too.
If there is a better approach to this, that would be nice, but currently i need to modify some access per folder and with the current setup everything is mixed at the root of the bucket, which is not good.