### PR TITLE
Protect from bad (non-importable) repo names, like those with dashes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "project_name",
-    "repo_name": "{{ cookiecutter.project_name|replace(' ', '_') }}",
+    "repo_name": "{{ cookiecutter.project_name|replace(' ', '_')|replace('-', '_') }}",
     "author_name": "Your Name",
     "email": "Your email",
     "description": "A short description of the project.",

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,4 @@
+repo_name = '{{ cookiecutter.repo_name }}'
+
+if hasattr(repo_name, 'isidentifier'):
+    assert repo_name.isidentifier(), 'Repo name should be valid Python identifier!'


### PR DESCRIPTION
OK, the README does say "repo_name must be a valid Python module name or you will have issues on imports".  But let's be kind to bad README readers (ahem, me) and bake in some insulation - especially since dashes are so common in project names.  Otherwise hitch produces this very confusing error:

    Command '['/home/catherine/.hitchpkg/postgresql-9.5.0/postgresql-9.5.0/bin/psql', '-d', 'template1', '-p', '15432', '--host', '/home/catherine/v/shared/rideshare-matchmaker/tests/.hitch/pgdata', '-c', "create user rideshare-matchmaker with password 'password';"]' returned non-zero exit status 1
