### PR TITLE
Add POSTGRES_USER environment variable to django service.

### DIFF
--- a/{{cookiecutter.repo_name}}/dev.yml
+++ b/{{cookiecutter.repo_name}}/dev.yml
@@ -17,6 +17,8 @@ services:
     command: python /app/manage.py runserver_plus 0.0.0.0:8000
     depends_on:
       - postgres
+    environment:
+      - POSTGRES_USER={{cookiecutter.repo_name}}
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
With the development docker configuration (docker-compose -f dev.yml), migrations are run as the default "postgres" user.  The postgres backup task is run as the "repo_name" user who doesn't have permission to read the tables because they were created and are owned by "postgres".  As a result, they are not included in the backup.  Example:

[before.sql.txt](https://github.com/pydanny/cookiecutter-django/files/176431/before.sql.txt)

Adding the POSTGRES_USER environment variable to the django service causes the tables to be created and owned by the "repo_name" user which results in a more complete backup:

[after.sql.txt](https://github.com/pydanny/cookiecutter-django/files/176432/after.sql.txt)