### PR TITLE
Template license in README.rst based on user's choice.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -64,7 +64,8 @@ Listed in alphabetical order.
   Cullen Rhodes            `@c-rhodes`_
   Daniele Tricoli          `@eriol`_
   David Díaz               `@ddiazpinto`_                @DavidDiazPinto
-  Davur Clementsen         `@dsclementsen`_             @davur
+  Davur Clementsen         `@dsclementsen`_              @davur
+  Dónal Adams              `@epileptic-fish`_
   Eraldo Energy            `@eraldo`_
   Eyad Al Sibai            `@eyadsibai`_
   Felipe Arruda            `@arruda`_
@@ -123,6 +124,8 @@ Listed in alphabetical order.
 .. _@ChrisPappalardo: https://github.com/ChrisPappalardo
 .. _@Collederas: https://github.com/Collederas
 .. _@ddiazpinto: https://github.com/ddiazpinto
+.. _@dsclementsen: https://github.com/dsclementsen
+.. _@epileptic-fish: https://gihub.com/epileptic-fish
 .. _@eraldo: https://github.com/eraldo
 .. _@eriol: https://github.com/eriol
 .. _@eyadsibai: https://github.com/eyadsibai

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -4,7 +4,9 @@
 {{cookiecutter.description}}
 
 
-LICENSE: BSD
+{% if cookiecutter.open_source_license != "Not open source" %}
+LICENSE: {{cookiecutter.open_source_license}}
+{% endif %}
 
 Settings
 ------------


### PR DESCRIPTION
Just a simple bugfix. I noticed that the generated README contained `LICENSE: BSD` despite me choosing `MIT`. `BSD` was hard-coded.