### PR TITLE
Deleting unnecessary .idea dir from MAIN directory

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
It seems that this file was committed by mistake in #507. Probably was confused with correct file `{{cookiecutter.repo_name}}/.idea/vcs.xml`