### PR TITLE
Mailhog as docker-container

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -42,14 +42,12 @@ django-allauth sends an email to verify users (and superusers) after signup and 
 
 .. _configure your email backend: http://docs.djangoproject.com/en/1.9/topics/email/#smtp-backend
 
-In development you can (optionally) use MailHog_ for email testing. MailHog is built with Go so there are no dependencies. To use MailHog::
+In development you can (optionally) use MailHog_ for email testing. MailHog is added as docker-container. To use MailHog::
 
-1. `Download the latest release`_ for your operating system
-2. Rename the executable to ``mailhog`` and copy it to the root of your project directory
-3. Make sure it is executable (e.g. ``chmod +x mailhog``)
+1. Make sure, that ``mailhog`` docker container is up and running
+2. Open your browser and go to ``http://127.0.0.1:8025``
 
 .. _Mailhog: https://github.com/mailhog/MailHog/
-.. _Download the latest release: https://github.com/mailhog/MailHog/releases
 
 Alternatively simply output emails to the console via: ``EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'``
 

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -41,14 +41,23 @@ You can now run the usual Django ``migrate`` and ``runserver`` commands::
 django-allauth sends an email to verify users (and superusers) after signup and login (if they are still not verified). To send email you need to `configure your email backend`_
 
 .. _configure your email backend: http://docs.djangoproject.com/en/1.9/topics/email/#smtp-backend
-
+{% if cookiecutter.use_docker == 'y' %}
 In development you can (optionally) use MailHog_ for email testing. MailHog is added as docker-container. To use MailHog::
 
 1. Make sure, that ``mailhog`` docker container is up and running
 2. Open your browser and go to ``http://127.0.0.1:8025``
 
 .. _Mailhog: https://github.com/mailhog/MailHog/
+{% else %}
+In development you can (optionally) use MailHog_ for email testing. MailHog is built with Go so there are no dependencies. To use MailHog::
 
+1. `Download the latest release`_ for your operating system
+2. Rename the executable to ``mailhog`` and copy it to the root of your project directory
+3. Make sure it is executable (e.g. ``chmod +x mailhog``)
+
+.. _Mailhog: https://github.com/mailhog/MailHog/
+.. _Download the latest release: https://github.com/mailhog/MailHog/releases
+{% endif %}
 Alternatively simply output emails to the console via: ``EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'``
 
 In production basic email configuration is setup to send emails with Mailgun_

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -70,6 +70,3 @@ node_modules/
 
 # Hitch directory
 tests/.hitch
-
-# MailHog binary
-mailhog

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -70,3 +70,7 @@ node_modules/
 
 # Hitch directory
 tests/.hitch
+{% if cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'n'%}
+# MailHog binary
+mailhog
+{% endif %}

--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -112,16 +112,10 @@ module.exports = function (grunt) {
       runDjango: {
         cmd: 'python <%= paths.manageScript %> runserver'
       },
-      {% if cookiecutter.use_mailhog == "y" -%}runMailHog: {
-        cmd: './mailhog'
-      },{%- endif %}
     }
   });
 
   grunt.registerTask('serve', [
-    {% if cookiecutter.use_mailhog == "y" -%}
-    'bgShell:runMailHog',
-    {%- endif %}
     'bgShell:runDjango',
     'watch'
   ]);

--- a/{{cookiecutter.repo_name}}/Gruntfile.js
+++ b/{{cookiecutter.repo_name}}/Gruntfile.js
@@ -112,10 +112,16 @@ module.exports = function (grunt) {
       runDjango: {
         cmd: 'python <%= paths.manageScript %> runserver'
       },
+      {% if cookiecutter.use_mailhog == "y" and cookiecutter.use_docker == 'n' -%}runMailHog: {
+        cmd: './mailhog'
+      },{%- endif %}
     }
   });
 
   grunt.registerTask('serve', [
+    {% if cookiecutter.use_mailhog == "y" and cookiecutter.use_docker == 'n' -%}
+    'bgShell:runMailHog',
+    {%- endif %}
     'bgShell:runDjango',
     'watch'
   ]);

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -77,7 +77,7 @@ Please note: For Celery's import magic to work, it is important *where* the cele
 
 Email Server
 ^^^^^^^^^^^^
-
+{% if cookiecutter.use_docker == 'y' %}
 In development, it is often nice to be able to see emails that are being sent from your application. For that reason local SMTP server `MailHog`_ with a web interface is available as docker container.
 
 .. _mailhog: https://github.com/mailhog/MailHog
@@ -86,7 +86,22 @@ Container mailhog will start automatically when you will run all docker containe
 Please check `cookiecutter-django Docker documentation`_ for more details how to start all containers.
 
 With MailHog running, to view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
+{% else %}
+In development, it is often nice to be able to see emails that are being sent from your application. If you choose to use `MailHog`_ when generating the project a local SMTP server with a web interface will be available.
 
+.. _mailhog: https://github.com/mailhog/MailHog
+
+To start the service, make sure you have nodejs installed, and then type the following::
+
+    $ npm install
+    $ grunt serve
+
+(After the first run you only need to type ``grunt serve``) This will start an email server that listens on ``127.0.0.1:1025`` in addition to starting your Django project and a watch task for live reload.
+
+To view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
+
+The email server will exit when you exit the Grunt task on the CLI with Ctrl+C.
+{% endif %}
 {% endif %}
 
 {% if cookiecutter.use_sentry == "y" %}

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -78,20 +78,14 @@ Please note: For Celery's import magic to work, it is important *where* the cele
 Email Server
 ^^^^^^^^^^^^
 
-In development, it is often nice to be able to see emails that are being sent from your application. If you choose to use `MailHog`_ when generating the project a local SMTP server with a web interface will be available.
+In development, it is often nice to be able to see emails that are being sent from your application. For that reason local SMTP server `MailHog`_ with a web interface is available as docker container.
 
 .. _mailhog: https://github.com/mailhog/MailHog
 
-To start the service, make sure you have nodejs installed, and then type the following::
+Container mailhog will start automatically when you will run all docker containers.
+Please check `cookiecutter-django Docker documentation`_ for more details how to start all containers.
 
-    $ npm install
-    $ grunt serve
-
-(After the first run you only need to type ``grunt serve``) This will start an email server that listens on ``127.0.0.1:1025`` in addition to starting your Django project and a watch task for live reload.
-
-To view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
-
-The email server will exit when you exit the Grunt task on the CLI with Ctrl+C.
+With MailHog running, to view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
 
 {% endif %}
 

--- a/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -26,7 +26,7 @@ SECRET_KEY = env('DJANGO_SECRET_KEY', default='CHANGEME!!!')
 
 EMAIL_PORT = 1025
 {% if cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'y' %}
-EMAIL_HOST = 'mailhog'
+EMAIL_HOST = env("EMAIL_HOST", default='mailhog')
 {% else %}
 EMAIL_HOST = 'localhost'
 EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',

--- a/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -23,12 +23,15 @@ SECRET_KEY = env('DJANGO_SECRET_KEY', default='CHANGEME!!!')
 
 # Mail settings
 # ------------------------------------------------------------------------------
-EMAIL_HOST = 'localhost'
+
 EMAIL_PORT = 1025
-{%if cookiecutter.use_mailhog == 'n' -%}
+{% if cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'y' %}
+EMAIL_HOST = 'mailhog'
+{% else %}
+EMAIL_HOST = 'localhost'
 EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',
                     default='django.core.mail.backends.console.EmailBackend')
-{%- endif %}
+{% endif %}
 
 # CACHING
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.repo_name}}/dev.yml
+++ b/{{cookiecutter.repo_name}}/dev.yml
@@ -28,6 +28,10 @@ services:
       - "8000:8000"
     links:
       - postgres
+{% if cookiecutter.use_mailhog == 'y' %}
+      - mailhog
+{% endif %}
+
 {% if cookiecutter.use_pycharm == 'y' %}
   pycharm:
     build:

--- a/{{cookiecutter.repo_name}}/dev.yml
+++ b/{{cookiecutter.repo_name}}/dev.yml
@@ -42,3 +42,10 @@ services:
     links:
       - postgres
 {% endif %}
+
+{% if cookiecutter.use_mailhog == 'y' %}
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "8025:8025"
+{% endif %}

--- a/{{cookiecutter.repo_name}}/tests/all.settings
+++ b/{{cookiecutter.repo_name}}/tests/all.settings
@@ -11,6 +11,7 @@ environment_variables:
   SECRET_KEY: cj5^uos4tfCdfghjkf5hq$9$(@-79^e9&x$3vyf#igvsfm4d=+
   CELERY_BROKER_URL: redis://localhost:16379
   DJANGO_EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+  EMAIL_HOST: localhost
 window_size:
   width: 1024
   height: 600


### PR DESCRIPTION
I created this PR, because I don't like the idea, that I have to download additional binaries:

from https://github.com/pydanny/cookiecutter-django/blob/master/docs/developing-locally.rst


> In development you can (optionally) use MailHog for email testing. MailHog is built with Go so there are no dependencies. To use MailHog:
> 
> Download the latest release for your operating system
> Rename the executable to mailhog and copy it to the root of your project directory
> Make sure it is executable (e.g. chmod +x mailhog)
> 

I think it is also better to not use grunt for running mailhog, and because also there are plans to [make grunt optional](https://github.com/pydanny/cookiecutter-django/issues/476) (https://github.com/pydanny/cookiecutter-django/issues/476), this will remove unnecessary dependency

