### PR TITLE
fix for failng test - version conflict of dateutil package

### DIFF
--- a/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
+++ b/{{cookiecutter.repo_name}}/tests/hitchreqs.txt
@@ -28,7 +28,7 @@ psutil==4.0.0
 ptyprocess==0.5.1
 pykwalify==1.5.0
 python-build==0.2.13
-python-dateutil==2.5.0
+python-dateutil==2.4.2
 pyuv==1.2.0
 PyYAML==3.11
 pyzmq==15.2.0


### PR DESCRIPTION
I have experienced problems with running tests with travis on new project generated from cookiecutter-django.

https://travis-ci.org/SpisTresci/SpisTresci/builds/122101955

```
Traceback (most recent call last):
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 635, in _build_master
    ws.require(__requires__)
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 943, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 834, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (python-dateutil 2.5.0 (/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages), Requirement.parse('python-dateutil==2.4.2'), {'pykwalify'})
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/bin/hitchtest", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2927, in <module>
    @_call_aside
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2913, in _call_aside
    f(*args, **kwargs)
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2940, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 637, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 650, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/home/travis/build/SpisTresci/SpisTresci/tests/.hitch/virtualenv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 829, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'python-dateutil==2.4.2' distribution was not found and is required by pykwalify
```

Conflict is between [pykwalify ver 1.5.0](https://github.com/Grokzen/pykwalify/blob/1.5.0/requirements.txt) (which use `python-dateutil==2.4.2`) and `python-dateutil` itself (defined in `tests/hitchreqs.txt`), which is in version 2.5.0. It seems that problem occur since https://github.com/pydanny/cookiecutter-django/pull/494 (CC: @luzfcb - could you also take a look on that?).

Downgrading `python-dateutil` back to version 2.4.2 [solved the issue for me](https://travis-ci.org/SpisTresci/SpisTresci/builds/122088660).