### PR TITLE
Small fixes to utility scripts

### DIFF
--- a/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
+++ b/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-OS_REQUIREMENTS_FILENAME="requirements.apt"
+WORK_DIR="$(dirname "$0")"
+OS_REQUIREMENTS_FILENAME="$WORK_DIR/requirements.apt"
 
 # Handle call with wrong command
 function wrong_command()

--- a/{{cookiecutter.project_slug}}/utility/install_python_dependencies.sh
+++ b/{{cookiecutter.project_slug}}/utility/install_python_dependencies.sh
@@ -45,6 +45,8 @@ else
 
     pip install -r requirements/local.txt
     pip install -r requirements/test.txt
+    {% if cookiecutter.use_heroku == "y" -%}
     pip install -r requirements.txt
+    {%- endif %}
 fi
 

--- a/{{cookiecutter.project_slug}}/utility/install_python_dependencies.sh
+++ b/{{cookiecutter.project_slug}}/utility/install_python_dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+WORK_DIR="$(dirname "$0")"
+PROJECT_DIR="$(dirname "$WORK_DIR")"
+
 pip --version >/dev/null 2>&1 || {
     echo >&2 -e "\npip is required but it's not installed."
     echo >&2 -e "You can install it by running the following command:\n"
@@ -43,10 +46,10 @@ if [ -z "$VIRTUAL_ENV" ]; then
     exit 1;
 else
 
-    pip install -r requirements/local.txt
-    pip install -r requirements/test.txt
+    pip install -r $PROJECT_DIR/requirements/local.txt
+    pip install -r $PROJECT_DIR/requirements/test.txt
     {% if cookiecutter.use_heroku == "y" -%}
-    pip install -r requirements.txt
+    pip install -r $PROJECT_DIR/requirements.txt
     {%- endif %}
 fi
 


### PR DESCRIPTION
Hello there,

This PR basically fixes two little bugs:

- `utility/install_python_requirements.sh` was trying to install `requirements.txt` even if project was created `use_heroku == 'n'`

- both utility scripts depended of being called from undocumented and inconsistent paths. Particularly, `install_python_requirements.sh` only worked if it was called from the top of the project, and `install_os_dependencies.sh` only worked if called from inside `utility/` folder. Now you can call them from wherever you want. 

Cheers!