### PR TITLE
Install python3-dev when not using python2

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -69,6 +69,7 @@ Listed in alphabetical order.
   Davur Clementsen         `@dsclementsen`_              @davur
   Dónal Adams              `@epileptic-fish`_
   Dong Huynh               `@trungdong`_
+  Emanuel Calso            `@bloodpet`_                  @bloodpet
   Eraldo Energy            `@eraldo`_
   Eyad Al Sibai            `@eyadsibai`_
   Felipe Arruda            `@arruda`_
@@ -123,6 +124,7 @@ Listed in alphabetical order.
 .. _@andor-pierdelacabeza: https://github.com/andor-pierdelacabeza
 .. _@areski: https://github.com/areski
 .. _@arruda: https://github.com/arruda
+.. _@bloodpet: https://github.com/bloodpet
 .. _@bogdal: https://github.com/bogdal
 .. _@burhan: https://github.com/burhan
 .. _@c-rhodes: https://github.com/c-rhodes

--- a/{{cookiecutter.project_slug}}/utility/requirements.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements.apt
@@ -3,7 +3,11 @@
 build-essential
 #required to translate
 gettext
+{% if cookiecutter.use_python2 == 'n' -%}
+python3-dev
+{% else %}
 python-dev
+{%- endif %}
 
 ##shared dependencies of:
 ##Pillow, pylibmc


### PR DESCRIPTION
By default, ubuntu-based distros would install python2-dev if you install python-dev.
The package python3-dev should be installed explicitly if we're not using python2.

I've encountered this problem in two cases:
- When spinning up a new distro and starting a cookiecutter-django project with python2="no"
- When cookiecutter-django in a distro where python2-dev is already installed, but I've selected the option python2=no