### PR TITLE
gh #498: Use docker alpine image

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/django/Dockerfile
@@ -1,7 +1,11 @@
+FROM alpine
+RUN  apk update
 {% if cookiecutter.use_python2 == 'n' -%}
-FROM python:3.5
-{% else %}
-FROM python:2.7
+RUN  apk add bash python3 libpq && ln -s /usr/bin/python3 /usr/bin/python
+RUN  pip3 install -U pip
+{%- else %}
+RUN  apk add bash python libpq curl
+RUN  curl https://bootstrap.pypa.io/get-pip.py | python
 {%- endif %}
 ENV PYTHONUNBUFFERED 1
 
@@ -10,7 +14,7 @@ COPY ./requirements /requirements
 
 RUN pip install -r /requirements/production.txt
 
-RUN groupadd -r django && useradd -r -g django django
+RUN addgroup django && adduser -D -G django -s /sbin/nologin django
 COPY . /app
 RUN chown -R django /app
 

--- a/{{cookiecutter.project_slug}}/compose/django/Dockerfile-dev
+++ b/{{cookiecutter.project_slug}}/compose/django/Dockerfile-dev
@@ -1,7 +1,11 @@
+FROM alpine
+RUN  apk update
 {% if cookiecutter.use_python2 == 'n' -%}
-FROM python:3.5
-{% else %}
-FROM python:2.7
+RUN  apk add bash python3 libpq && ln -s /usr/bin/python3 /usr/bin/python
+RUN  pip3 install -U pip
+{%- else %}
+RUN  apk add bash python libpq curl
+RUN  curl https://bootstrap.pypa.io/get-pip.py | python
 {%- endif %}
 ENV PYTHONUNBUFFERED 1
 

--- a/{{cookiecutter.project_slug}}/compose/django/gunicorn.sh
+++ b/{{cookiecutter.project_slug}}/compose/django/gunicorn.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python /app/manage.py collectstatic --noinput
-/usr/local/bin/gunicorn config.wsgi -w 4 -b 0.0.0.0:5000 --chdir=/app
+/usr/bin/gunicorn config.wsgi -w 4 -b 0.0.0.0:5000 --chdir=/app

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,11 +1,3 @@
-{% if cookiecutter.use_python2 == 'n' -%}
-# Wheel 0.25+ needed to install certain packages on CPython 3.5+
-# like Pillow and psycopg2
-# See http://bitly.com/wheel-building-fails-CPython-35
-# Verified bug on Python 3.5.1
-wheel==0.29.0
-{%- endif %}
-
 # Bleeding edge Django
 django==1.9.7
 
@@ -25,7 +17,15 @@ django-floppyforms==1.6.2
 django-model-utils==2.5
 
 # Images
+{% if cookiecutter.use_docker == 'n' -%}
 Pillow==3.2.0
+{%- else %}
+  {%- if cookiecutter.use_python2 == 'y' %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/Pillow-3.2.0-cp27-cp27mu-linux_x86_64.whl
+  {%- else %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/Pillow-3.2.0-cp35-cp35m-linux_x86_64.whl
+  {%- endif %}
+{%- endif %}
 
 # For user registration, either via email or social
 # Well-built with regular release cycles!
@@ -36,7 +36,15 @@ django-allauth==0.25.2
 # from http://www.lfd.uci.edu/~gohlke/pythonlibs/#psycopg
 {% else %}
 # Python-PostgreSQL Database Adapter
+  {%- if cookiecutter.use_docker == 'n' %}
 psycopg2==2.6.1
+  {%- else %}
+    {%- if cookiecutter.use_python2 == 'y' %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/psycopg2-2.6.1-cp27-cp27mu-linux_x86_64.whl
+    {%- else %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/psycopg2-2.6.1-cp35-cp35m-linux_x86_64.whl
+    {%- endif %}
+  {%- endif %}
 {%- endif %}
 
 # Unicode slugification

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -7,12 +7,29 @@
 # If using Win for dev, this assumes Unix in prod
 # ------------------------------------------------
 psycopg2==2.6.1
+{%- elif cookiecutter.use_docker == 'y' %}
+  {%- if cookiecutter.use_python2 == 'y' %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/psycopg2-2.6.1-cp27-cp27mu-linux_x86_64.whl
+  {%- else %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/psycopg2-2.6.1-cp35-cp35m-linux_x86_64.whl
+  {%- endif %}
 {%- endif %}
 
 # WSGI Handler
 # ------------------------------------------------
-gevent==1.1.1
 gunicorn==19.6.0
+{% if cookiecutter.use_docker == 'n' -%}
+gevent==1.1.1
+{%- else %}
+  {%- if cookiecutter.use_python2 == 'y' %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/greenlet-0.4.9-cp27-cp27mu-linux_x86_64.whl
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/gevent-1.1.1-cp27-cp27mu-linux_x86_64.whl
+  {%- else %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/greenlet-0.4.9-cp35-cp35m-linux_x86_64.whl
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/greenlet-0.4.9-cp35-cp35m-linux_x86_64.whl
+  {%- endif %}
+{%- endif %}
+
 
 # Static and Media Storage
 # ------------------------------------------------

--- a/{{cookiecutter.project_slug}}/requirements/test.txt
+++ b/{{cookiecutter.project_slug}}/requirements/test.txt
@@ -5,6 +5,12 @@
 # Python-PostgreSQL Database Adapter
 # If using Win for dev, this assumes Unix in test/prod
 psycopg2==2.6.1
+{%- elif cookiecutter.use_docker == 'y' %}
+  {%- if cookiecutter.use_python2 == 'y' %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/psycopg2-2.6.1-cp27-cp27mu-linux_x86_64.whl
+  {%- else %}
+https://github.com/mzdaniel/alpinewheels/releases/download/v1.0/psycopg2-2.6.1-cp35-cp35m-linux_x86_64.whl
+  {%- endif %}
 {%- endif %}
 
 coverage==4.1


### PR DESCRIPTION
Preliminary work to use lightweight docker alpine image.
Created https://github.com/mzdaniel/alpinewheels as pypi doesn't have yet support for musl libc, nor a tag that we can use.
This is a proof of concept to discuss the implementation details and improve it.
Development is working with postgres support and production properly launches all containers (though boto seems to insist in aws credentials raising exception. gunicorn seems to be active)
