### PR TITLE
Fix CONTRIBUTORS.rst (malformed table, unknown target name docutil errors)

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -187,6 +187,8 @@ Listed in alphabetical order.
 .. _@yunti: https://github.com/yunti
 .. _@zcho: https://github.com/zcho
 .. _@noisy: https://github.com/noisy
+.. _@krzysztofzuraw: https://github.com/krzysztofzuraw
+.. _@blopker: https://github.com/blopker
 
 Special Thanks
 ~~~~~~~~~~~~~~

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -116,7 +116,7 @@ Listed in alphabetical order.
   Théo Segonds             `@show0k`_
   Tom Atkins               `@knitatoms`_
   Tom Offermann
-  Travis McNeill           `@Travistock`_              @tavistock_esq
+  Travis McNeill           `@Travistock`_               @tavistock_esq
   Vitaly Babiy
   Vivian Guillen           `@viviangb`_
   Yaroslav Halchenko

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -122,7 +122,6 @@ Listed in alphabetical order.
   Yaroslav Halchenko
 ========================== ============================ ==============
 
-.. _@dezoito: https://github.com/dezoito
 .. _@a7p: https://github.com/a7p
 .. _@ad-m: https://github.com/ad-m
 .. _@aeikenberry: https://github.com/aeikenberry
@@ -132,6 +131,7 @@ Listed in alphabetical order.
 .. _@areski: https://github.com/areski
 .. _@arruda: https://github.com/arruda
 .. _@bloodpet: https://github.com/bloodpet
+.. _@blopker: https://github.com/blopker
 .. _@bogdal: https://github.com/bogdal
 .. _@burhan: https://github.com/burhan
 .. _@c-rhodes: https://github.com/c-rhodes
@@ -143,6 +143,7 @@ Listed in alphabetical order.
 .. _@ChrisPappalardo: https://github.com/ChrisPappalardo
 .. _@Collederas: https://github.com/Collederas
 .. _@ddiazpinto: https://github.com/ddiazpinto
+.. _@dezoito: https://github.com/dezoito
 .. _@dot2dotseurat: https://github.com/dot2dotseurat
 .. _@dsclementsen: https://github.com/dsclementsen
 .. _@epileptic-fish: https://gihub.com/epileptic-fish
@@ -158,7 +159,6 @@ Listed in alphabetical order.
 .. _@ikkebr: https://github.com/ikkebr
 .. _@iynaix: https://github.com/iynaix
 .. _@jazztpt: https://github.com/jazztpt
-.. _@xpostudio4: https://github.com/xpostudio4
 .. _@juliocc: https://github.com/juliocc
 .. _@jvanbrug: https://github.com/jvanbrug
 .. _@ka7eh: https://github.com/ka7eh
@@ -166,29 +166,29 @@ Listed in alphabetical order.
 .. _@kappataumu: https://github.com/kappataumu
 .. _@kevgathuku: https://github.com/kevgathuku
 .. _@knitatoms: https://github.com/knitatoms
+.. _@krzysztofzuraw: https://github.com/krzysztofzuraw
 .. _@MathijsHoogland: https://github.com/MathijsHoogland
 .. _@menzenski: https://github.com/menzenski
 .. _@mfwarren: https://github.com/mfwarren
 .. _@mjsisley: https://github.com/mjsisley
 .. _@mozillazg: https://github.com/mozillazg
+.. _@noisy: https://github.com/noisy
 .. _@originell: https://github.com/originell
 .. _@oubiga: https://github.com/oubiga
-.. _@romanosipenko: https://github.com/romanosipenko
 .. _@raonyguimaraes: https://github.com/raonyguimaraes
+.. _@romanosipenko: https://github.com/romanosipenko
+.. _@shireenrao: https://github.com/shireenrao
 .. _@show0k: https://github.com/show0k
 .. _@siauPatrick: https://github.com/siauPatrick
-.. _@shireenrao: https://github.com/shireenrao
 .. _@slafs: https://github.com/slafs
 .. _@stepmr: https://github.com/stepmr
 .. _@suledev: https://github.com/suledev
 .. _@Travistock: https://github.com/Tavistock
 .. _@trungdong: https://github.com/trungdong
 .. _@viviangb: httpsL//github.com/viviangb
+.. _@xpostudio4: https://github.com/xpostudio4
 .. _@yunti: https://github.com/yunti
 .. _@zcho: https://github.com/zcho
-.. _@noisy: https://github.com/noisy
-.. _@krzysztofzuraw: https://github.com/krzysztofzuraw
-.. _@blopker: https://github.com/blopker
 
 Special Thanks
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
The [Other Contributors](https://github.com/pydanny/cookiecutter-django/blob/master/CONTRIBUTORS.rst#other-contributors) table could not be rendered due to an error introduced in 38c6fb7. Some target names were missing as well.