### PR TITLE
WIP: Add webpack as an option

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -122,6 +122,7 @@ Listed in alphabetical order.
   Travis McNeill           `@Travistock`_               @tavistock_esq
   Vitaly Babiy
   Vivian Guillen           `@viviangb`_
+  Will Farley              `@goldhand`_                 @g01dhand
   Yaroslav Halchenko
 ========================== ============================ ==============
 
@@ -156,6 +157,7 @@ Listed in alphabetical order.
 .. _@eyadsibai: https://github.com/eyadsibai
 .. _@garry-cairns: https://github.com/garry-cairns
 .. _@garrypolley: https://github.com/garrypolley
+.. _@goldhand: https://github.com/goldhand
 .. _@hackebrot: https://github.com/hackebrot
 .. _@hairychris: https://github.com/hairychris
 .. _@hjwp: https://github.com/hjwp

--- a/README.rst
+++ b/README.rst
@@ -152,10 +152,12 @@ For development, see the following for local development:
 
 * `Developing locally`_
 * `Developing locally using docker`_
+* `Developing locally using webpack`_
 
 .. _options: http://cookiecutter-django.readthedocs.io/en/latest/project-generation-options.html
 .. _`Developing locally`: http://cookiecutter-django.readthedocs.io/en/latest/developing-locally.html
 .. _`Developing locally using docker`: http://cookiecutter-django.readthedocs.io/en/latest/developing-locally-docker.html
+.. _`Developing locally using webpack`: http://cookiecutter-django.readthedocs.io/en/latest/developing-locally-webpack.html
 
 Community
 -----------

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
     "use_docker": "y",
     "use_heroku": "n",
     "use_compressor": "n",
-    "js_task_runner": ["Gulp", "Grunt", "None"],
+    "js_task_runner": ["Gulp", "Grunt", "Webpack", "None"],
     "use_lets_encrypt": "n",
     "open_source_license": ["MIT", "BSD", "Apache Software License 2.0", "Not open source"]
 }

--- a/docs/developing-locally-webpack.rst
+++ b/docs/developing-locally-webpack.rst
@@ -1,0 +1,144 @@
+Developing Locally with Webpack
+===============================
+
+.. index:: Webpack, React, Redux, Karma, HMR
+
+The steps below will get you up and running with a super speedy local development environment with Webpack, React, Redux and Hot module Replacement.
+
+Before you begin, make sure you've created a python virtual environment, installed local python dependencies and created a postres database::
+
+    $ virtualenv env
+    $ source env/bin/activate
+    $ pip install -r requirements/local.txt
+    $ createdb [project_slug]
+    $ python manage.py migrate
+    $ python manage.py runserver
+
+These prerequisite steps are detailed more in the `developing locally section`_. If you've already done them, continue to installing javascript dependencies.
+
+.. _developing locally section: https://cookiecutter-django.readthedocs.io/en/latest/developing-locally.html
+
+
+Install javascript dependencies
+-------------------------------
+
+You will need `NodeJS`_ set up on your local machine to use `npm`_.
+
+.. _NodeJS: https://nodejs.org/en/
+.. _npm: https://www.npmjs.com/
+
+
+Install all the javascript dev dependencies as specified in the ``.package.json`` file::
+
+    $ npm install
+
+
+Start the django and webpack servers
+------------------------------------
+
+Start up the python and webpack dev server's::
+
+    $ npm start
+
+
+Open up ``http://localhost:8000`` to see the project running in your browser.
+
+You can also open ``http://localhost:8080`` to see the webpack-dev-server running.
+
+**Why are there two servers? Why not use django's built in static file server?**
+
+We are using webpack's dev server to enable `hot module replacement`_.
+
+If you're not familiar with hmr, then try editing one of the react components that was generated in your static directory.
+You will see your updates without any page reloading.
+Because we have sass loaders in our webpack configuration, this also applies to style edits.
+
+.. _hot module replacement: https://webpack.github.io/docs/hot-module-replacement.html
+
+
+**Static Project Structure**
+
+The static project is in your django project's static root, specifically: ``[ project_slug ]/static/[ project_slug ]``.
+
+There is also a generated ``README.md`` in that directory that outlines the React + Redux + Webpack project structure.
+
+
+Running Tests with karma
+------------------------
+
+Javascript tests are in the ``[ project_slug ]/static/[ project_slug ]/__tests__/`` directory.
+
+To run karma::
+
+    $ npm test
+
+This will also run eslint on your javascript files because it is a loader in the webpack test config.
+
+To keep karma running and watch for file changes run::
+
+    $ npm watch:test
+
+
+Deployment with webpack
+-----------------------
+
+To build your assets for production deployment::
+
+    $ npm run build
+
+This will bundle all your files and place them in the ``[ project_slug ]/static/[ project_slug ]/dist/`` directory as specified in the webpack production config's ``output.path``.
+
+There is a generated ``webpack-stats-production.json`` file that contains references to webpack's built files that django will need in production. It is ignored by git but you will want to make sure it is included in deployment.
+
+
+Bundling static assets
+----------------------
+
+You can "bundle" (webpack term) all your static assets into separate modules for each page. When webpack bundles these assets it looks for entry points that you specify (in ``config.entry``) and loads all that entry points dependencies into the bundle, if that entry point has dependencies, webpack will load those dependencies and so on recursively. You can even include image files and style sheets as dependencies too.
+
+The current webpack configuration that is built in the django-cookiecutter project is already configured to create three bundles, ``main``, ``vendor`` and ``common``.
+
+* ``main`` contains the main project app, currently a counter demo.
+* ``vendor`` contains all the third party code, currently react, redux and related libraries. We isolate ``vendor`` because it is likely to be shared between apps and will also not be updated in production as much as our ``main`` bundle so it can stay cached.
+* ``common`` contains shared modules between bundles.
+
+These bundles are being served locally by the webpack-development-server when you run ``npm start``.
+
+Bundles need to be included in django templates. Bundles are hashed each build though, so you can't just add a script tag for them.
+We use ``django-webpack-loader`` to make Django aware of webpack's build stats. In templates, we can use tags provided by ``django-webpack-loader`` to reference each bundle with the correct build hash.
+
+.. code-block:: django
+
+    <!--base.html-->
+    {% load render_bundle from webpack_loader %}
+    ...
+    {% block javascript %}
+    <!-- render 'main' bundle with correct build hash -->
+    {% render_bundle 'main' %}
+    {% endblock javascript %}
+
+**Bundling Example:**
+
+Say we create a new module for user administration. We don't want to include it in the main app because it's only needed in the user page.
+
+We would first create a seperate entry point in our ``./config/webpack.base.config.js`` file:
+
+.. code-block:: javascript
+
+    entry: {
+        main: './assets/js/index',  // the entry that already exists for our main app
+        users: './assets/js/userApp', // create a new entry for our userApp called 'users'
+    }
+
+
+Then we can load that bundle in our ``users.html`` template:
+
+.. code-block:: django
+
+    <!--users.html-->
+    {% load render_bundle from webpack_loader %}
+    ...
+    {% block javascript %}
+    {{ block.super }}
+    {% render_bundle 'users' %}
+    {% endblock javascript %}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents:
    project-generation-options
    developing-locally
    developing-locally-docker
+   developing-locally-webpack
    settings
    linters
    live-reloading-and-sass-compilation

--- a/docs/linters.rst
+++ b/docs/linters.rst
@@ -41,3 +41,19 @@ The config for pep8 is located in setup.cfg. It specifies:
 
 * Set max line length to 120 chars
 * Exclude .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
+
+
+eslint
+------
+
+If you are using webpack, an ``.eslint`` file will be generated in your project base.
+
+Running the karma tests will also run the linter.
+
+    $ npm test
+
+You can manually run the eslint from your project root too:
+
+    $ eslint <javascript files that you wish to lint>
+
+Using the flag ``--fix`` will atomatically fix any errors.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 import os
 import random
 import shutil
+from cookiecutter.main import cookiecutter
 
 # Get the root project directory
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
@@ -161,6 +162,30 @@ def remove_packageJSON_file():
             PROJECT_DIRECTORY, filename
         ))
 
+
+def add_webpack():
+    """
+    Adds webpack configuration using cookiecutter to install hzdg/cookiecutter-webpack
+    """
+    cookiecutter(
+        'git@github.com:hzdg/cookiecutter-webpack.git',
+        replay=False, overwrite_if_exists=True, output_dir='../',
+        checkout='pydanny-django', no_input=True, extra_context={
+            'project_name': '{{ cookiecutter.project_name }}',
+            'repo_name': '{{ cookiecutter.project_slug }}',
+            'repo_owner': '',
+            'project_dir': '{{ cookiecutter.project_slug }}',
+            'static_root': '{{ cookiecutter.project_slug }}/static/{{ cookiecutter.project_slug }}',
+            'production_output_path': '{{ cookiecutter.project_slug }}/static/{{ cookiecutter.project_slug }}/dist/',
+            'author_name': '{{ cookiecutter.author_name }}',
+            'description': '{{ cookiecutter.description }}',
+            'version': '{{ cookiecutter.version }}',
+            'existing_project': 'y',
+            'css_extension': 'sass',
+            'use_ejs': 'n',
+            'open_source_license': '{{ cookiecutter.open_source_license }}'
+        })
+
 def remove_certbot_files():
     """
     Removes files needed for certbot if it isn't going to be used
@@ -212,6 +237,11 @@ if '{{ cookiecutter.js_task_runner}}'.lower() == 'gulp':
     remove_grunt_files()
 elif '{{ cookiecutter.js_task_runner}}'.lower() == 'grunt':
     remove_gulp_files()
+elif '{{ cookiecutter.js_task_runner }}'.lower() == 'webpack':
+    remove_gulp_files()
+    remove_grunt_files()
+    remove_packageJSON_file()
+    add_webpack()
 else:
     remove_gulp_files()
     remove_grunt_files()

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -55,8 +55,30 @@ Running javascript tests with karma
 ::
 
   $ npm test
-{% endif %}
 
+
+Hot reloading with React and Webpack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install npm depenencies::
+
+  $ npm install
+
+Start the development server::
+
+  $ npm start
+
+
+A more detailed explanation for `Developing locally with webpack`_
+
+
+The `static project readme`_ contains a lot of information about React / Redux and Webpack for this project.
+
+.. _`static project readme`: {{ cookiecutter.project_slug }}/static/{{ cookiecutter.project_slug }}/README.md
+.. _`Developing locally with webpack`: http://cookiecutter-django.readthedocs.io/en/latest/developing-locally-webpack.html
+
+
+{% else %}
 
 Live reloading and Sass CSS compilation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,6 +87,7 @@ Moved to `Live reloading and SASS compilation`_.
 
 .. _`Live reloading and SASS compilation`: http://cookiecutter-django.readthedocs.io/en/latest/live-reloading-and-sass-compilation.html
 
+{% endif %}
 {% if cookiecutter.use_celery == "y" %}
 
 Celery

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -47,6 +47,16 @@ Running tests with py.test
 ::
 
   $ py.test
+{% if cookiecutter.js_task_runner == 'Webpack' %}
+
+Running javascript tests with karma
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+  $ npm test
+{% endif %}
+
 
 Live reloading and Sass CSS compilation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -243,5 +243,18 @@ STATICFILES_FINDERS += ("compressor.finders.CompressorFinder", )
 
 # Location of root django.contrib.admin URL, use {% raw %}{% url 'admin:index' %}{% endraw %}
 ADMIN_URL = r'^admin/'
+{% if cookiecutter.js_task_runner == 'Webpack' %}
+# WEBPACK
+# ------------------------------------------------------------------------------
+INSTALLED_APPS += ('webpack_loader',)
+# Webpack Local Stats file
+STATS_FILE = ROOT_DIR('webpack-stats.json')
+# Webpack config
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'STATS_FILE': STATS_FILE
+    }
+}
+{% endif %}
 
 # Your common stuff: Below this line define 3rd party library settings

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -303,5 +303,19 @@ LOGGING = {
 {% endif %}
 # Custom Admin URL, use {% raw %}{% url 'admin:index' %}{% endraw %}
 ADMIN_URL = env('DJANGO_ADMIN_URL')
+{% if cookiecutter.js_task_runner == 'Webpack' %}
+
+# WEBPACK
+# ------------------------------------------------------------------------------
+# Webpack Production Stats file
+STATS_FILE = ROOT_DIR('webpack-stats-production.json')
+# Webpack config
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'BUNDLE_DIR_NAME': '{{ cookiecutter.project_slug }}/static/{{ cookiecutter.project_slug }}/dist/',
+        'STATS_FILE': STATS_FILE
+    }
+}
+{% endif %}
 
 # Your production stuff: Below this line define 3rd party library settings

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -58,4 +58,9 @@ celery==3.1.23
 django_compressor==2.0
 {% endif %}
 
+{% if cookiecutter.js_task_runner == 'Webpack' -%}
+# Webpack
+django-webpack-loader==0.3.0
+{%- endif %}
+
 # Your custom requirements go here

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -1,4 +1,5 @@
-{% raw %}{% load staticfiles i18n {% endraw %}{% if cookiecutter.use_compressor == "y" %}compress{% endif %}{% raw %}%}<!DOCTYPE html>
+{% raw %}{% load staticfiles i18n {% endraw %}{% if cookiecutter.use_compressor == "y" %}compress {% endif %}{% raw %}%}
+{% endraw %}{% if cookiecutter.js_task_runner == 'Webpack' -%}{% raw %}{% load render_bundle from webpack_loader %}{% endraw %}{%- endif %}{% raw %}<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -76,7 +77,9 @@
               <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}">{{ message }}</div>
           {% endfor %}
       {% endif %}
-
+{% endraw %}{% if cookiecutter.js_task_runner == 'Webpack' %}{% raw %}
+      <div id="main"></div>
+{% endraw %}{% endif %}{% raw %}
       {% block content %}
         <p>Use this document as a way to quick start any new project.</p>
       {% endblock content %}
@@ -99,12 +102,17 @@
       <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
 
       <!-- Your stuff: Third-party javascript libraries go here -->
-
+{% endraw %}{% if cookiecutter.js_task_runner == 'Webpack' %}{% raw %}
+      <!-- Webpack bundles -->
+      {% render_bundle 'vendor' %}
+      {% render_bundle 'common' %}
+      {% render_bundle 'main' %}
+{% endraw %}{% else %}{% raw %}
       <!-- place project specific Javascript in this file -->
       {% endraw %}{% if cookiecutter.use_compressor == "y" %}{% raw %}{% compress js %}{% endraw %}{% endif %}{% raw %}
       <script src="{% static 'js/project.js' %}"></script>
       {% endraw %}{% if cookiecutter.use_compressor == "y" %}{% raw %}{% endcompress %}{% endraw %}{% endif %}{% raw %}
-
+{% endraw %}{% endif %}{% raw %}
     {% endblock javascript %}
   </body>
 </html>


### PR DESCRIPTION
This adds `Webpack` as an option in `js_task_runner`.

Still a work in progress but aims to resolve #538 

Works now but will need some work to be accepted. I just wanted to present this and collect feedback.

Unlike the grunt and gulp task runner options, this will clone a webpack config from [cookiecutter-webpack@pydanny-django](https://github.com/hzdg/cookiecutter-webpack/tree/pydanny-django)

* The `pydanny-django` branch of `cookiecutter-webpack` is dedicated to supporting this project and any changes that need to happen for `cookiecutter-webpack` to integrate well into here can be added in that branch (if there's a discrepancy with `master`).
* A package.json file will be generated that can be used to run the python and webpack hot reload server
* The webpack configuration files will be inserted into `/config/` and follow a similar pattern to the django settings. (`base`, `local` and `production`).
* Currently, this will also make react, redux and karma a part of the project (probably need to make those optional. Can consider make them options in the `cookiecutter-webpack` repo. This will also solve  #466 ).
* ~~There's a `less` loader in the webpack config that needs to be removed along with the less file in the demo.~~
* The app is currently injected into a `<div id="main"></div>` node in the base template but that can be changed if there's a better idea for how it should be integrated with django templates.
* Currently puts all webpack related static files into the dir `{{ project_slug }}/static/{{ project_slug }}`
* This webpack build doesn't go very well with the current static file dirs. Need to figure out a better structure.

To test this out, just select `3` (`Webpack`) as the option for `js_task_runner` and cd into the new project.

run `pip install -r requirements/local.txt && npm install`

to start the server with hot reloading enabled and a demo react / redux counter app run `npm start` and open up `localhost:8000`.

To run karma tests on static files run `npm test`.






