### PR TITLE
Tweak env vars section of docs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -48,6 +48,7 @@ Listed in alphabetical order.
   Andrew Mikhnevich        `@zcho`_
   Andy Rose
   Anna Callahan            `@jazztpt`_
+  Antonia Blair            `@antoniablair`_             @antoniablairart
   Areski Belaid            `@areski`_
   Ashley Camba
   Barclay Gauld            `@yunti`_
@@ -128,6 +129,7 @@ Listed in alphabetical order.
 .. _@alb3rto: https://github.com/alb3rto
 .. _@amjith: https://github.com/amjith
 .. _@andor-pierdelacabeza: https://github.com/andor-pierdelacabeza
+.. _@antoniablair: https://github.com/antoniablair
 .. _@areski: https://github.com/areski
 .. _@arruda: https://github.com/arruda
 .. _@bloodpet: https://github.com/bloodpet

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -26,20 +26,22 @@ You can now run the usual Django ``migrate`` and ``runserver`` commands::
     $ python manage.py migrate
     $ python manage.py runserver
 
-At this point you can take a break from setup and start getting to know the files in the project. 
+At this point you can take a break from setup and start getting to know the files in the project.
 
-But if you want to go further with setup, read on. 
+But if you want to go further with setup, read on.
 
 (Note: the following sections still need to be revised)
 
 Setting Up Env Vars for Production
 -----------------------------------
-    
-`Cookiecutter Django` uses the excellent `django-environ`_ package with its ``DATABASE_URL`` environment variable to simplify database configuration in your Django settings. Now all you have to do is rename env.example to .env and then compose a definition for ``DATABASE_URL`` as shown below and add it to the .env file:
+
+`Cookiecutter Django` uses the excellent `django-environ`_ package, which includes a ``DATABASE_URL`` environment variable to simplify database configuration in your Django settings.
+
+Rename env.example to .env to begin updating the file with your own environment variables. To add your database, define ``DATABASE_URL`` and add it to the .env file, as shown below:
 
 .. parsed-literal::
 
-    $ export DATABASE_URL="postgres://*<pg_user_name>*:*<pg_user_password>*\ @127.0.0.1:\ *<pg_port>*/*<pg_database_name>*"
+    DATABASE_URL="postgres://*<pg_user_name>*:*<pg_user_password>*\ @127.0.0.1:\ *<pg_port>*/*<pg_database_name>*"
 
 .. _django-environ: http://django-environ.readthedocs.io
 


### PR DESCRIPTION
I updated the .env section of Getting Up and Running Locally to show that 'export' is not needed in the .env file and break up some longer sentences.