### PR TITLE
Added OS requirements for Debian Jessie.

### DIFF
--- a/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
+++ b/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
@@ -6,9 +6,9 @@ DISTRO_NAME=$(lsb_release -sc)
 OS_REQUIREMENTS_FILENAME="$WORK_DIR/requirements-$DISTRO_NAME.apt"
 
 
-if [ "$DISTRO_NAME" != "xenial" ] && [ "$DISTRO_NAME" != "trusty" ]; then
-  echo "Only the Ubuntu 14.04 (Trusty) and 16.04 (Xenial) is supported by this script";
-  echo "You can see requirements-trusty.apt or requirements-xenial.apt file to help search the equivalent package in your system";
+if [ "$DISTRO_NAME" != "xenial" ] && [ "$DISTRO_NAME" != "trusty" ] && [ "$DISTRO_NAME" != "jessie" ]; then
+  echo "Only the Ubuntu 14.04 (Trusty), 16.04 (Xenial) and Debian 8.x (Jessie) is supported by this script";
+  echo "You can see requirements-trusty.apt, requirements-xenial.apt or requirements-jessie.apt file to help search the equivalent package in your system";
   exit 1;
 fi
 

--- a/{{cookiecutter.project_slug}}/utility/requirements-jessie.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-jessie.apt
@@ -1,0 +1,27 @@
+##basic build dependencies of various Django apps for Debian Jessie 8.x
+#build-essential metapackage install: make, gcc, g++,
+build-essential
+#required to translate
+gettext
+{% if cookiecutter.use_python2 == 'n' -%}
+python3-dev
+{% else %}
+python-dev
+{%- endif %}
+
+##shared dependencies of:
+##Pillow, pylibmc
+zlib1g-dev
+
+##Postgresql and psycopg2 dependencies
+libpq-dev
+
+##Pillow dependencies
+libtiff5-dev
+libjpeg62-turbo-dev
+libfreetype6-dev
+liblcms2-dev
+libwebp-dev
+
+##django-extensions
+graphviz-dev


### PR DESCRIPTION
After a brief talk with @pydanny about the intention of this PR, I pull it again.

The intention of this PR is add a new OS requirements set of Debian Jessie for the script `install_os_dependencies.sh` , extending this way the current two: Ubuntu Trusty and Ubuntu Xenial. Since the merge of #605, a new set of OS requirements for an apt-based distribution can be added through a file called requirements-$(lsb_release -sc).

This new set of requirements are conveniently tested and, of course, I offer myself to keep this set of requirements updated.