### PR TITLE
Changed nginx confs for dockers new networking

### DIFF
--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -89,7 +89,7 @@ If you would like to set up autorenewal of your certificates, the following comm
 
     #!/bin/bash
     cd <project directory>
-    docker-compose run certbot bash -c "sleep 6 && certbot certonly --standalone -d {{ cookiecutter.domain_name }} --text --agree-tos --email {{ cookiecutter.email }} --server https://acme-v01.api.letsencrypt.org/directory --rsa-key-size 4096 --verbose --keep-until-expiring --standalone-supported-challenges http-01"
+    docker-compose run --rm --name certbot certbot bash -c "sleep 6 && certbot certonly --standalone -d {{ cookiecutter.domain_name }} --text --agree-tos --email {{ cookiecutter.email }} --server https://acme-v01.api.letsencrypt.org/directory --rsa-key-size 4096 --verbose --keep-until-expiring --standalone-supported-challenges http-01"
     docker exec pearl_nginx_1 nginx -s reload
 
 And then set a cronjob by running `crontab -e` and placing in it (period can be adjusted as desired)::

--- a/{{cookiecutter.project_slug}}/compose/nginx/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/nginx/Dockerfile
@@ -5,4 +5,5 @@ ADD nginx.conf /etc/nginx/nginx.conf
 ADD start.sh /start.sh
 ADD nginx-secure.conf /etc/nginx/nginx-secure.conf
 ADD dhparams.pem /etc/ssl/private/dhparams.pem
+CMD /start.sh
 {% endif %}

--- a/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
+++ b/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
@@ -37,10 +37,12 @@ http {
 		server_name ___my.example.com___ www.___my.example.com___;
 
 		location /.well-known/acme-challenge {
-			proxy_pass http://certbot:80;
+			# Since the certbot container isn't up constantly, need to resolve ip dynamically using docker's dns
+			resolver ___NAMESERVER___;
+			set $certbot_addr_port certbot:80;
+			proxy_pass http://$certbot_addr_port;
 			proxy_set_header Host            $host;
 			proxy_set_header X-Forwarded-For $remote_addr;
-			proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Proto $scheme;
 		}
 
@@ -66,7 +68,9 @@ http {
 		ssl_dhparam /etc/ssl/private/dhparams.pem;
 
 		location /.well-known/acme-challenge {
-			proxy_pass http://certbot:443;
+			resolver ___NAMESERVER___;
+			set $certbot_addr_port certbot:443;
+			proxy_pass http://$certbot_addr_port;
 			proxy_set_header Host            $host;
 			proxy_set_header X-Forwarded-For $remote_addr;
 			proxy_set_header X-Forwarded-Proto https;

--- a/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
+++ b/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
@@ -37,7 +37,7 @@ http {
 		server_name ___my.example.com___ www.___my.example.com___;
 
 		location /.well-known/acme-challenge {
-			proxy_pass http://___LETSENCRYPT_IP___:___LETSENCRYPT_PORT___;
+			proxy_pass http://certbot:80;
 			proxy_set_header Host            $host;
 			proxy_set_header X-Forwarded-For $remote_addr;
 			proxy_set_header X-Forwarded-Proto https;
@@ -66,7 +66,7 @@ http {
 		ssl_dhparam /etc/ssl/private/dhparams.pem;
 
 		location /.well-known/acme-challenge {
-			proxy_pass http://___LETSENCRYPT_HTTPS_IP___:___LETSENCRYPT_HTTPS_PORT___;
+			proxy_pass http://certbot:443;
 			proxy_set_header Host            $host;
 			proxy_set_header X-Forwarded-For $remote_addr;
 			proxy_set_header X-Forwarded-Proto https;

--- a/{{cookiecutter.project_slug}}/compose/nginx/nginx.conf
+++ b/{{cookiecutter.project_slug}}/compose/nginx/nginx.conf
@@ -39,7 +39,7 @@ http {
 		server_name ___my.example.com___ ;
 
 		location /.well-known/acme-challenge {
-			proxy_pass http://___LETSENCRYPT_IP___:___LETSENCRYPT_PORT___;
+			proxy_pass http://certbot:80;
 			proxy_set_header Host            $host;
 			proxy_set_header X-Forwarded-For $remote_addr;
 			proxy_set_header X-Forwarded-Proto https;

--- a/{{cookiecutter.project_slug}}/compose/nginx/start.sh
+++ b/{{cookiecutter.project_slug}}/compose/nginx/start.sh
@@ -49,8 +49,14 @@ echo replacing ___my.example.com___/$MY_DOMAIN_NAME
 # Put your domain name into the nginx reverse proxy config.
 sed -i "s/___my.example.com___/$MY_DOMAIN_NAME/g" /etc/nginx/nginx-secure.conf
 
+# Add the system's nameserver (the docker network dns) so we can resolve container names in nginx
+NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+echo replacing ___NAMESERVER___/$NAMESERVER
+sed -i "s/___NAMESERVER___/$NAMESERVER/g" /etc/nginx/nginx-secure.conf
+
+
 #go!
-kill $(ps aux | grep 'nginx' | awk '{print $2}')
+kill $(ps aux | grep 'nginx' | grep -v 'grep' | awk '{print $2}')
 cp /etc/nginx/nginx-secure.conf /etc/nginx/nginx.conf
 
 nginx -g 'daemon off;'

--- a/{{cookiecutter.project_slug}}/compose/nginx/start.sh
+++ b/{{cookiecutter.project_slug}}/compose/nginx/start.sh
@@ -5,18 +5,9 @@ echo build starting nginx config
 
 
 echo replacing ___my.example.com___/$MY_DOMAIN_NAME
-echo replacing ___LETSENCRYPT_IP___/$LETSENCRYPT_PORT_80_TCP_ADDR
-echo replacing ___LETSENCRYPT_PORT___/$LETSENCRYPT_PORT_80_TCP_PORT
-echo replacing ___APPLICATION_IP___/$APP_PORT_80_TCP_ADDR
-echo replacing ___APPLICATION_PORT___/$APP_PORT_80_TCP_PORT
 
 # Put your domain name into the nginx reverse proxy config.
 sed -i "s/___my.example.com___/$MY_DOMAIN_NAME/g" /etc/nginx/nginx.conf
-# Add your app's container IP and port into config
-sed -i "s/___APPLICATION_IP___/$APP_PORT_80_TCP_ADDR/g" /etc/nginx/nginx.conf
-sed -i "s/___APPLICATION_PORT___/$APP_PORT_80_TCP_PORT/g" /etc/nginx/nginx.conf
-sed -i "s/___LETSENCRYPT_IP___/$LETSENCRYPT_PORT_80_TCP_ADDR/g" /etc/nginx/nginx.conf
-sed -i "s/___LETSENCRYPT_PORT___/$LETSENCRYPT_PORT_80_TCP_PORT/g" /etc/nginx/nginx.conf
 
 cat /etc/nginx/nginx.conf
 echo .
@@ -53,26 +44,10 @@ done
 sleep 15
 
 echo replacing ___my.example.com___/$MY_DOMAIN_NAME
-echo replacing ___LETSENCRYPT_IP___/$LETSENCRYPT_PORT_80_TCP_ADDR
-echo replacing ___LETSENCRYPT_PORT___/$LETSENCRYPT_PORT_80_TCP_PORT
-echo replacing ___LETSENCRYPT_HTTPS_IP___/$LETSENCRYPT_PORT_443_TCP_ADDR
-echo replacing ___LETSENCRYPT_HTTPS_PORT___/$LETSENCRYPT_PORT_443_TCP_PORT
-echo replacing ___APPLICATION_IP___/$APP_PORT_80_TCP_ADDR
-echo replacing ___APPLICATION_PORT___/$APP_PORT_80_TCP_PORT
 
 
 # Put your domain name into the nginx reverse proxy config.
 sed -i "s/___my.example.com___/$MY_DOMAIN_NAME/g" /etc/nginx/nginx-secure.conf
-
-# Add LE container IP and port into config
-sed -i "s/___LETSENCRYPT_IP___/$LETSENCRYPT_PORT_80_TCP_ADDR/g" /etc/nginx/nginx-secure.conf
-sed -i "s/___LETSENCRYPT_PORT___/$LETSENCRYPT_PORT_80_TCP_PORT/g" /etc/nginx/nginx-secure.conf
-sed -i "s/___LETSENCRYPT_HTTPS_IP___/$LETSENCRYPT_PORT_443_TCP_ADDR/g" /etc/nginx/nginx-secure.conf
-sed -i "s/___LETSENCRYPT_HTTPS_PORT___/$LETSENCRYPT_PORT_443_TCP_PORT/g" /etc/nginx/nginx-secure.conf
-
-# Add your app's container IP and port into config
-sed -i "s/___APPLICATION_IP___/$APP_PORT_80_TCP_ADDR/g" /etc/nginx/nginx-secure.conf
-sed -i "s/___APPLICATION_PORT___/$APP_PORT_80_TCP_PORT/g" /etc/nginx/nginx-secure.conf
 
 #go!
 kill $(ps aux | grep 'nginx' | awk '{print $2}')


### PR DESCRIPTION
Docker got rid of legacy links so there are no longer env vars pointing
to other containers. Instead, we can reference the containers directly.
This fixes problems with let's encrypt related to missing env vars.
See notice at the top of
https://docs.docker.com/compose/link-env-deprecated/

Fixes #626 