### PR TITLE
Improve `install_os_dependencies.sh`

### DIFF
--- a/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
+++ b/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
@@ -2,39 +2,48 @@
 
 WORK_DIR="$(dirname "$0")"
 DISTRO_NAME=$(lsb_release -sc)
+OS_REQUIREMENTS_FILENAME="requirements-$DISTRO_NAME.apt"
 
-OS_REQUIREMENTS_FILENAME="$WORK_DIR/requirements-$DISTRO_NAME.apt"
+cd $WORK_DIR
 
-
-if [ "$DISTRO_NAME" != "xenial" ] && [ "$DISTRO_NAME" != "trusty" ] && [ "$DISTRO_NAME" != "jessie" ]; then
-  echo "Only the Ubuntu 14.04 (Trusty), 16.04 (Xenial) and Debian 8.x (Jessie) is supported by this script";
-  echo "You can see requirements-trusty.apt, requirements-xenial.apt or requirements-jessie.apt file to help search the equivalent package in your system";
-  exit 1;
+# Check if a requirements file exist for the current distribution.
+if [ ! -r "$OS_REQUIREMENTS_FILENAME" ]; then
+    cat <<-EOF >&2
+		There is no requirements file for your distribution.
+		You can see one of the files listed below to help search the equivalent package in your system:
+		`find ./ -name "requirements-*.apt" -printf "  - %f\n"`
+	EOF
+    exit 1;
 fi
 
 # Handle call with wrong command
 function wrong_command()
 {
-  echo "${0##*/} - unknown command: '${1}'"
-  usage_message
+    echo "${0##*/} - unknown command: '${1}'" >&2
+    usage_message
 }
 
 # Print help / script usage
 function usage_message()
 {
-  echo "usage: ./${0##*/} <command>"
-  echo "available commands are:"
-  echo -e "\tlist\t\tPrint a list of all packages defined on ${OS_REQUIREMENTS_FILENAME} file"
-  echo -e "\thelp\t\tPrint this help"
-  echo -e "\n\tCommands that require superuser permission:"
-  echo -e "\tinstall\t\tInstall packages defined on ${OS_REQUIREMENTS_FILENAME} file. Note: This\n\t\t\t   does not upgrade the packages already installed for new\n\t\t\t   versions, even if new version is available in the repository."
-  echo -e "\tupgrade\t\tSame that install, but upgrate the already installed packages,\n\t\t\t   if new version is available."
+    cat <<-EOF
+		Usage: $WORK_DIR/${0##*/} <command>
+		Available commands are:
+		    list        Print a list of all packages defined on ${OS_REQUIREMENTS_FILENAME} file
+		    help        Print this help
 
+		Commands that require superuser permission:
+		    install     Install packages defined on ${OS_REQUIREMENTS_FILENAME} file. Note: This
+		                does not upgrade the packages already installed for new versions, even if
+		                new version is available in the repository.
+		    upgrade     Same that install, but upgrade the already installed packages, if new
+		                version is available.
+	EOF
 }
 
 # Read the requirements.apt file, and remove comments and blank lines
 function list_packages(){
-     grep -v "#" "${OS_REQUIREMENTS_FILENAME}" | grep -v "^$";
+    grep -v "#" "${OS_REQUIREMENTS_FILENAME}" | grep -v "^$";
 }
 
 function install_packages()
@@ -47,18 +56,17 @@ function upgrade_packages()
     list_packages | xargs apt-get install -y;
 }
 
-
 function install_or_upgrade()
 {
     P=${1}
     PARAN=${P:-"install"}
 
     if [[ $EUID -ne 0 ]]; then
-        echo -e "\nYou must run this with root privilege" 2>&1
-        echo -e "Please do:\n" 2>&1
-        echo "sudo ./$WORK_DIR/${0##*/} $PARAN" 2>&1
-        echo -e "\n" 2>&1
-
+        cat <<-EOF >&2
+			You must run this script with root privilege
+			Please do:
+			sudo $WORK_DIR/${0##*/} $PARAN
+		EOF
         exit 1
     else
 
@@ -76,16 +84,13 @@ function install_or_upgrade()
 
         exit 0
     fi
-
-
 }
-
 
 # Handle command argument
 case "$1" in
     install) install_or_upgrade;;
     upgrade) install_or_upgrade "upgrade";;
     list) list_packages;;
-    help) usage_message;;
+    help|"") usage_message;;
     *) wrong_command "$1";;
 esac

--- a/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
+++ b/{{cookiecutter.project_slug}}/utility/install_os_dependencies.sh
@@ -11,7 +11,7 @@ if [ ! -r "$OS_REQUIREMENTS_FILENAME" ]; then
     cat <<-EOF >&2
 		There is no requirements file for your distribution.
 		You can see one of the files listed below to help search the equivalent package in your system:
-		`find ./ -name "requirements-*.apt" -printf "  - %f\n"`
+		$(find ./ -name "requirements-*.apt" -printf "  - %f\n")
 	EOF
     exit 1;
 fi


### PR DESCRIPTION
This PR improve some things of the `install_os_dependencies.sh` script. In particular:

- Checks if a requirements file exist for the current distribution (which means that is supported) instead of be implicitly defined inside the script.
- Uses HEREDOC for grouping text and improve readability, specially for the usage messages. Regrettably, HEREDOC can only be indented with tabs.
- Redirects all the error messages to the error standard output. I suppose that the above redirection `2>&1` was an error and it should actually be `>&2`. If there is a reason to redirect all the errors to the standard output, please tell me and I'll fix it.
- Fixed some minor typos