### PR TITLE
Use project_slug instead of project_name for cookiecutter-webpack

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -85,6 +85,7 @@ Listed in alphabetical order.
   Ian Lee                  `@IanLee1521`_
   Jan Van Bruggen          `@jvanbrug`_
   Jens Nilsson             `@phiberjenz`_
+  Jiun Wei Chia            `@jiunwei`_                   @jiunwei
   Julien Almarcha          `@sladinji`_
   Julio Castillo           `@juliocc`_
   Kaido Kert               `@kaidokert`_

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -171,7 +171,7 @@ def add_webpack():
         'https://github.com/hzdg/cookiecutter-webpack.git',
         replay=False, overwrite_if_exists=True, output_dir='../',
         checkout='pydanny-django', no_input=True, extra_context={
-            'project_name': '{{ cookiecutter.project_name }}',
+            'project_name': '{{ cookiecutter.project_slug }}',
             'repo_name': '{{ cookiecutter.project_slug }}',
             'repo_owner': '',
             'project_dir': '{{ cookiecutter.project_slug }}',


### PR DESCRIPTION
With a `project_name` that has a space and selecting Webpack as `js_task_runner`, `npm install` fails with npm version 3.9.2 on Mac:

```
npm WARN Invalid name: "My Test Project"
npm WARN my_test_project No description
npm WARN my_test_project No repository field.
npm WARN my_test_project No README data
npm WARN my_test_project No license field.
```

To avoid this, this pull request changes the `add_webpack()` hook so `project_slug` is used instead of `project_name` when installing `hzdg/cookiecutter-webpack`. `tox` tests are unaffected.