### PR TITLE
Update deployment-on-heroku.rst

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -16,8 +16,8 @@ You can either push the 'deploy' button in your generated README.rst or run thes
     heroku addons:create heroku-redis:hobby-dev
     heroku addons:create mailgun
 
-    heroku config:set DJANGO_ADMIN_URL=`openssl rand -base64 32`
-    heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 64`
+    heroku config:set DJANGO_ADMIN_URL="$(openssl rand -base64 32)"
+    heroku config:set DJANGO_SECRET_KEY="$(openssl rand -base64 64)"
     heroku config:set DJANGO_SETTINGS_MODULE='config.settings.production'
     heroku config:set DJANGO_ALLOWED_HOSTS='.herokuapp.com'
 


### PR DESCRIPTION
On linux this `openssl` command usually creates inappropriate strings and the 'ticks' don't guard against it.  My way, works everytime. Noob friendly.