### PR TITLE
Hide django-compressor comment section

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -238,9 +238,9 @@ else:
 ########## END CELERY
 {% endif %}
 
+{% if cookiecutter.use_compressor == 'y'-%}
 # django-compressor
 # ------------------------------------------------------------------------------
-{% if cookiecutter.use_compressor == 'y'-%}
 INSTALLED_APPS += ("compressor", )
 STATICFILES_FINDERS += ("compressor.finders.CompressorFinder", )
 {%- endif %}


### PR DESCRIPTION
If you choose to not use `django-compressor`, it will still leave a comment section for that library.
This should hide it if you don't choose that option.