### PR TITLE
Update crispy forms template pack

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -165,7 +165,7 @@ TEMPLATES = [
 ]
 
 # See: http://django-crispy-forms.readthedocs.io/en/latest/install.html#template-packs
-CRISPY_TEMPLATE_PACK = 'bootstrap3'
+CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # STATIC FILE CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Updated to be inline with bootstrap 4 currently used in the project