### PR TITLE
Wait for the postgres container to start

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/django/Dockerfile-dev
+++ b/{{cookiecutter.project_slug}}/compose/django/Dockerfile-dev
@@ -13,6 +13,10 @@ COPY ./compose/django/entrypoint.sh /entrypoint.sh
 RUN sed -i 's/\r//' /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+COPY ./compose/django/start-dev.sh /start-dev.sh
+RUN sed -i 's/\r//' /start-dev.sh
+RUN chmod +x /start-dev.sh
+
 WORKDIR /app
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/{{cookiecutter.project_slug}}/compose/django/entrypoint.sh
+++ b/{{cookiecutter.project_slug}}/compose/django/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+cmd="$@"
+
 # This entrypoint is used to play nicely with the current cookiecutter configuration.
 # Since docker-compose relies heavily on environment variables itself for configuration, we'd have to define multiple
 # environment variables just to support cookiecutter out of the box. That makes no sense, so this little entrypoint
@@ -15,4 +17,23 @@ export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres:5432/$
 {% if cookiecutter.use_celery == 'y' %}
 export CELERY_BROKER_URL=$REDIS_URL/0
 {% endif %}
-exec "$@"
+
+function postgres_ready(){
+python << END
+import sys
+import psycopg2
+try:
+    conn = psycopg2.connect(dbname="$POSTGRES_USER", user="$POSTGRES_USER", password="$POSTGRES_PASSWORD", host="postgres")
+except psycopg2.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+END
+}
+
+until postgres_ready; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up - continuing..."
+exec $cmd

--- a/{{cookiecutter.project_slug}}/compose/django/start-dev.sh
+++ b/{{cookiecutter.project_slug}}/compose/django/start-dev.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+python manage.py migrate
+python manage.py runserver_plus 0.0.0.0:8000

--- a/{{cookiecutter.project_slug}}/dev.yml
+++ b/{{cookiecutter.project_slug}}/dev.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: .
       dockerfile: ./compose/django/Dockerfile-dev
-    command: python /app/manage.py runserver_plus 0.0.0.0:8000
+    command: /start-dev.sh
     depends_on:
       - postgres
     environment:


### PR DESCRIPTION
This is a backport from https://cookiecutter-saas.com

It adds a small python script to `entrypoint.sh` that checks if the postgres container is up and running. If postgres is not up yet, it waits for a second and tries again.

Related issue: https://github.com/pydanny/cookiecutter-django/issues/602

We had a couple of issues with the entrypoint on windows in the past. Could someone confirm this works on windows before merging this in?