### PR TITLE
Fix jinja error by adding missing 'raw' tag

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/account/email.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/account/email.html
@@ -1,3 +1,4 @@
+{% raw %}
 {% extends "account/base.html" %}
 
 {% load i18n %}
@@ -76,3 +77,4 @@
 $('.form-group').removeClass('row');
 </script>
 {% endblock %}
+{% endraw %}


### PR DESCRIPTION
I have encountered error while using the latest commit. Add the raw tag back and everything goes well.


> Traceback (most recent call last):
  File "/Users/michael/.virtualenvs/chatbot/bin/cookiecutter", line 11, in <module>
    sys.exit(main())
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/cookiecutter/cli.py", line 106, in main
    config_file=user_config
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/cookiecutter/main.py", line 144, in cookiecutter
    output_dir=output_dir
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/cookiecutter/generate.py", line 350, in generate_files
    generate_file(project_dir, infile, context, env)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/cookiecutter/generate.py", line 168, in generate_file
    tmpl = env.get_template(infile_fwd_slashes)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/jinja2/environment.py", line 812, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/jinja2/environment.py", line 786, in _load_template
    template = self.loader.load(self, name, globals)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/jinja2/loaders.py", line 125, in load
    code = environment.compile(source, name, filename)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/jinja2/environment.py", line 565, in compile
    self.handle_exception(exc_info, source_hint=source_hint)
  File "/Users/michael/.virtualenvs/chatbot/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "./{{cookiecutter.project_slug}}/templates/account/email.html", line 3, in template
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'load'.
  File "./{{cookiecutter.project_slug}}/templates/account/email.html", line 3
    {% load i18n %}
