### PR TITLE
Replace unicode-slugify with awesome-slugify

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -40,7 +40,7 @@ psycopg2==2.6.2
 {%- endif %}
 
 # Unicode slugification
-unicode-slugify==0.1.3
+awesome-slugify==1.6.5
 django-autoslug==1.9.3
 
 # Time zones support


### PR DESCRIPTION
awesome-slugify: https://github.com/dimka665/awesome-slugify
Per @pydanny's comment.

Resolves #758 

That was _too_ easy, is there anything else I'm missing?
I've searched `slugify`, there's also `slugify.slugify` function in the settings — still valid with the new package.

Maybe add something in the docs, but where? I'm not familiar with the project yet, but docs look like they need some loving :–)