### PR TITLE
Create 403_csrf.html

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403_csrf.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403_csrf.html
@@ -1,0 +1,9 @@
+{% raw %}{% extends "base.html" %}
+
+{% block title %}Forbidden (403){% endblock %}
+
+{% block content %}
+<h1>Forbidden (403)</h1>
+
+<p>CSRF verification failed. Request aborted.</p>
+{% endblock content %}{% endraw %}


### PR DESCRIPTION
This takes advantage of the ability to easily customize the 403 template for CSRF by creating 403_csrf.html, introduced in Django 1.10.