### PR TITLE
Update readme to point to cookiecutter>=1.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ and then editing the results to include your name, email, and various configurat
 
 First, get Cookiecutter. Trust me, it's awesome::
 
-    $ pip install cookiecutter
+    $ pip install "cookiecutter>=1.4.0"
 
 Now run it against this repo::
 


### PR DESCRIPTION
I struggled with a stale version of cookiecutter on my machine. That being said indicating that it requires a specific version or great would have helped reduce the pain of getting started.
