### PR TITLE
Elastic Beanstalk: Added --noinput to migate command

### DIFF
--- a/{{cookiecutter.project_slug}}/.ebextensions/40_python.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/40_python.config
@@ -1,6 +1,6 @@
 container_commands:
   01_migrate:
-    command: "source /opt/python/run/venv/bin/activate && python manage.py migrate"
+    command: "source /opt/python/run/venv/bin/activate && python manage.py migrate --noinput"
     leader_only: True
   02_collectstatic:
     command: "source /opt/python/run/venv/bin/activate && python manage.py collectstatic --noinput"


### PR DESCRIPTION
When deploying with a stale content type the migration command can ask for user input which fails the deployment.

Example error output without this:
```
ERROR: Command failed on instance. Return code: 1 Output: (TRUNCATED)...s/management.py", line 158, in update_contenttypes
Type 'yes' to continue, or 'no' to cancel: """ % content_type_display)
EOFError: EOF when reading a line
```