### PR TITLE
Add documentation for Docker users on Windows

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -110,6 +110,7 @@ Listed in alphabetical order.
   Matt Warren              `@mfwarren`_
   Matthew Sisley           `@mjsisley`_
   Meghan Heintz            `@dot2dotseurat`_
+  Michael Gecht            `@mimischi`_                  @_mischi
   mozillazg                `@mozillazg`_
   Pablo                    `@oubiga`_
   Parbhat Puri             `@parbhat`_
@@ -191,6 +192,7 @@ Listed in alphabetical order.
 .. _@MathijsHoogland: https://github.com/MathijsHoogland
 .. _@menzenski: https://github.com/menzenski
 .. _@mfwarren: https://github.com/mfwarren
+.. _@mimischi: https://github.com/mimischi
 .. _@mjsisley: https://github.com/mjsisley
 .. _@mozillazg: https://github.com/mozillazg
 .. _@noisy: https://github.com/noisy

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -20,6 +20,16 @@ If you don't already have it installed, follow the instructions for your OS:
 .. _`Docker for Windows`: https://docs.docker.com/engine/installation/windows/
 .. _`docker-engine`: https://docs.docker.com/engine/installation/
 
+Attention Windows users
+-------------
+
+Currently PostgreSQL (``psycopg2`` python package) is not installed inside Docker containers for Windows users, while it is required by the generated Django project. To fix this, add ``psycopg2`` to the list of requirements inside ``requirements/base.txt``::
+
+    # Python-PostgreSQL Database Adapter
+    psycopg2==2.6.2
+
+Doing this will prevent the project from being installed in an Windows-only environment (thus without usage of Docker). If you want to use this project without Docker, make sure to remove ``psycopg2`` from the requirements again.
+
 Build the Stack
 ---------------
 


### PR DESCRIPTION
`psycopg2` is currently not installed when using Docker on an Windows environment. Before this gets fixed (see #841), we need some documentation around this issue.
