### PR TITLE
update raven to version 5.31.0 to avoid runtime crash in py3.5

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -58,6 +58,7 @@ Listed in alphabetical order.
   Benjamin Abel
   Bo Lopker                `@blopker`_
   Bouke Haarsma
+  Brent Payne              `@brentpayne`_               @brentpayne
   Burhan Khalid            `@burhan`_                   @burhan
   Catherine Devlin         `@catherinedevlin`_
   Cédric Gaspoz            `@cgaspoz`_

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -29,7 +29,7 @@ django-anymail==0.5
 {% if cookiecutter.use_sentry_for_error_reporting == "y" -%}
 # Raven is the Sentry client
 # --------------------------
-raven==5.30.0
+raven==5.31.0
 {%- endif %}
 
 {% if cookiecutter.use_opbeat == "y" -%}


### PR DESCRIPTION
Executive Summary:  any cookiecutter application with sentry would have a runtime error under python 3.5 when running `gunicorn config.wsgi:application`.   The issue is fixed in raven version 5.31.0

Extra Info:
I jumped down a rabbit hole with figuring out why my fresh cookiecutter app was having a runtime error on heroku.  Turns out raven 5.30 was causing a runtime error when adding its middleware to a django wsgi application.   The error was specifically in the **\_\_init\_\_** of SentryMiddleware did not except arguments.  The following monkey patch in the `wsgi.py` fixed the issue.

```
old_init = raven.contrib.django.middleware.SentryMiddleware.__init__
def new_init(self, *args, **kwargs):
    old_init(self)
raven.contrib.django.middleware.SentryMiddleware.__init__ = new_init
```

But the issue is already fixed in raven version 5.31.0.  Recommending that the cookiecutter be updated to generate requirement files with `raven==5.31.0`

All tests passed even in python 3.5 (before and after fix).  _py35_ isn't currently a default environment in tox, but I decided to just leave the `tox.ini` as is for this update.