### PR TITLE
Security: Upgrade gevent to alpha release 1.2a1

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -11,7 +11,7 @@ psycopg2==2.6.2
 
 # WSGI Handler
 # ------------------------------------------------
-gevent==1.1.2
+gevent==1.2a1
 gunicorn==19.6.0
 
 # Static and Media Storage


### PR DESCRIPTION
The current gevent alpha release fixes a couple of security issues. The bot won't pick this up, because it's pre release.

Should we upgrade anyway? 

### Changelog
```
Security
--------
- :mod:`gevent.pywsgi` now checks that the values passed to
``start_response`` do not contain a carriage return or newline in
order to prevent HTTP response splitting (header injection), raising
a :exc:`ValueError` if they do. See :issue:`775`.
- Incoming headers containing an underscore are no longer placed in
the WSGI environ. See :issue:`819`.
- Errors logged by :class:`~gevent.pywsgi.WSGIHandler` no
longer print the entire WSGI environment by default. This avoids
possible information disclosure vulnerabilities. Applications can
also opt-in to a higher security level for the WSGI environment if they
choose and their frameworks support it. Originally reported
in :pr:`779` by sean-peters-au and changed in :pr:`781`.
```