### PR TITLE
nginx-secure.conf mixed tabs/spaces to only spaces

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
+++ b/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
@@ -11,7 +11,7 @@ events {
 
 http {
 
-	include       /etc/nginx/mime.types;
+    include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -32,57 +32,57 @@ http {
     upstream app {
         server django:5000;
     }
-	server {
-		listen 80;
-		server_name ___my.example.com___ www.___my.example.com___;
+    server {
+        listen 80;
+        server_name ___my.example.com___ www.___my.example.com___;
 
-		location /.well-known/acme-challenge {
-			# Since the certbot container isn't up constantly, need to resolve ip dynamically using docker's dns
-			resolver ___NAMESERVER___;
-			set $certbot_addr_port certbot:80;
-			proxy_pass http://$certbot_addr_port;
-			proxy_set_header Host            $host;
-			proxy_set_header X-Forwarded-For $remote_addr;
+        location /.well-known/acme-challenge {
+            # Since the certbot container isn't up constantly, need to resolve ip dynamically using docker's dns
+            resolver ___NAMESERVER___;
+            set $certbot_addr_port certbot:80;
+            proxy_pass http://$certbot_addr_port;
+            proxy_set_header Host            $host;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
-		}
+        }
 
-		location / {
-			return         301 https://$server_name$request_uri;
-		}
+        location / {
+            return         301 https://$server_name$request_uri;
+        }
 
-	}
+    }
 
-	server {
-		listen 443;
-		server_name ___my.example.com___ www.___my.example.com___;
+    server {
+        listen 443;
+        server_name ___my.example.com___ www.___my.example.com___;
 
-		ssl on;
-		ssl_certificate /etc/letsencrypt/live/___my.example.com___/fullchain.pem;
-		ssl_certificate_key /etc/letsencrypt/live/___my.example.com___/privkey.pem;
-		ssl_session_timeout 5m;
-		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-		ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
-		ssl_prefer_server_ciphers on;
+        ssl on;
+        ssl_certificate /etc/letsencrypt/live/___my.example.com___/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/___my.example.com___/privkey.pem;
+        ssl_session_timeout 5m;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+        ssl_prefer_server_ciphers on;
 
-		ssl_session_cache shared:SSL:10m;
-		ssl_dhparam /etc/ssl/private/dhparams.pem;
+        ssl_session_cache shared:SSL:10m;
+        ssl_dhparam /etc/ssl/private/dhparams.pem;
 
-		location /.well-known/acme-challenge {
-			resolver ___NAMESERVER___;
-			set $certbot_addr_port certbot:443;
-			proxy_pass http://$certbot_addr_port;
-			proxy_set_header Host            $host;
-			proxy_set_header X-Forwarded-For $remote_addr;
-			proxy_set_header X-Forwarded-Proto https;
-		}
+        location /.well-known/acme-challenge {
+            resolver ___NAMESERVER___;
+            set $certbot_addr_port certbot:443;
+            proxy_pass http://$certbot_addr_port;
+            proxy_set_header Host            $host;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto https;
+        }
 
-		location / {
+        location / {
             # checks for static file, if not found proxy to app
             try_files $uri @proxy_to_app;
         }
 
-		# cookiecutter-django app
-		location @proxy_to_app {
+        # cookiecutter-django app
+        location @proxy_to_app {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;
@@ -91,6 +91,6 @@ http {
 
         }
 
-	}
+    }
 
 }


### PR DESCRIPTION
The mixed tabs/spaces make this file a bit hard to read on github, this PR changes it to use only spaces.