### PR TITLE
Update doc links from getsentry.com to sentry.io

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -130,6 +130,7 @@ Listed in alphabetical order.
   Sule Marshall            `@suledev`_
   Taylor Baldwin
   Théo Segonds             `@show0k`_
+  Tim Freund               `@timfreund`_
   Tom Atkins               `@knitatoms`_
   Tom Offermann
   Travis McNeill           `@Travistock`_               @tavistock_esq
@@ -211,6 +212,7 @@ Listed in alphabetical order.
 .. _@ssteinerX: https://github.com/ssteinerx
 .. _@stepmr: https://github.com/stepmr
 .. _@suledev: https://github.com/suledev
+.. _@timfreund: https://github.com/timfreund
 .. _@Travistock: https://github.com/Tavistock
 .. _@trungdong: https://github.com/trungdong
 .. _@viviangb: httpsL//github.com/viviangb

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Optional Integrations
 .. _Celery: http://www.celeryproject.org/
 .. _Anymail: https://github.com/anymail/django-anymail
 .. _MailHog: https://github.com/mailhog/MailHog
-.. _Sentry: https://getsentry.com/welcome/
+.. _Sentry: https://sentry.io/welcome/
 .. _docker-compose: https://github.com/docker/compose
 .. _Opbeat: https://opbeat.com/
 .. _PythonAnywhere: https://www.pythonanywhere.com/

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -107,7 +107,7 @@ The email server will exit when you exit the Grunt task on the CLI with Ctrl+C.
 Sentry
 ^^^^^^
 
-Sentry is an error logging aggregator service. You can sign up for a free account at  https://getsentry.com/signup/?code=cookiecutter  or download and host it yourself.
+Sentry is an error logging aggregator service. You can sign up for a free account at  https://sentry.io/signup/?code=cookiecutter  or download and host it yourself.
 The system is setup with reasonable defaults, including 404 logging and integration with the WSGI application.
 
 You must set the DSN url in production.

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -35,7 +35,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 {%- if cookiecutter.use_sentry_for_error_reporting == 'y' %}
 # raven sentry client
-# See https://docs.getsentry.com/hosted/clients/python/integrations/django/
+# See https://docs.sentry.io/clients/python/integrations/django/
 INSTALLED_APPS += ('raven.contrib.django.raven_compat', )
 {% endif %}
 {%- if cookiecutter.use_whitenoise == 'y' %}


### PR DESCRIPTION
Sentry changed their name and URLs:
https://blog.sentry.io/2016/08/30/sentry-io.html Links in the
cookiecutter-django project are updated to reflect the new locations.