### PR TITLE
env.example and .env #944

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -16,6 +16,8 @@ ROOT_DIR = environ.Path(__file__) - 3  # ({{ cookiecutter.project_slug }}/config
 APPS_DIR = ROOT_DIR.path('{{ cookiecutter.project_slug }}')
 
 env = environ.Env()
+# Assumes .env exists one folder above where manage.py exists
+env.read_env(str((ROOT_DIR - 1).path('.env')))  # reads the environment file
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
saves others from the same mistake when recreating .env

My .env file was embedded in my repo and I cleaned out my repo thinking every file in it was version controlled, only to find a key file missing.
Then recreating the .env file, I accidentally left a python string ' at the end and didn't catch it until now.

issue: #944
@schacki, I immediately appreciated your idea.

Signed-off-by: TidyData <mckweb@outlook.com>