### PR TITLE
Remove mention of the deploy button from Heroku docs

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -3,7 +3,7 @@ Deployment on Heroku
 
 .. index:: Heroku
 
-You can either push the 'deploy' button in your generated README.rst or run these commands to deploy the project to Heroku:
+Run these commands to deploy the project to Heroku:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Commit 04a58d5 removed the Heroku instant deploy button but the docs
still mention this as an option, this commit updates the docs to reflect
this change.