### PR TITLE
Inconsistent title case in 404

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/404.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/404.html
@@ -1,9 +1,9 @@
 {% raw %}{% extends "base.html" %}
 
-{% block title %}Page Not found{% endblock %}
+{% block title %}Page not found{% endblock %}
 
 {% block content %}
-<h1>Page Not found</h1>
+<h1>Page not found</h1>
 
 <p>This is not the page you were looking for.</p>
 {% endblock content %}{% endraw %}


### PR DESCRIPTION
We should either title case it or just capitalise the first letter, imho.