### PR TITLE
WIP: load .env file from root dir only if DJANGO_READ_DOT_ENV_FILE is True

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -3,7 +3,14 @@ Settings
 
 This project relies extensively on environment settings which **will not work with Apache/mod_wsgi setups**. It has been deployed successfully with both Gunicorn/Nginx and even uWSGI/Nginx.
 
-For configuration purposes, the following table maps environment variables to their Django setting:
+For configuration purposes, the following table maps environment variables to their Django setting and project settings:
+
+
+======================================= =========================== ============================================== ======================================================================
+Environment Variable                    Django Setting              Development Default                            Production Default
+======================================= =========================== ============================================== ======================================================================
+DJANGO_READ_DOT_ENV_FILE                READ_DOT_ENV_FILE           False                                          False
+======================================= =========================== ============================================== ======================================================================
 
 
 ======================================= =========================== ============================================== ======================================================================

--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -24,7 +24,7 @@ env = environ.Env()
 READ_DOT_ENV_FILE = env('DJANGO_READ_DOT_ENV_FILE', default=False)
 
 if READ_DOT_ENV_FILE:
-    # Operating System Environment variables have precende over variables defined in the .env file,
+    # Operating System Environment variables have precedence over variables defined in the .env file,
     # that is to say variables from the .env files will only be used if not defined
     # as environment variables.
     env_file = str(ROOT_DIR.path('.env'))

--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -16,7 +16,21 @@ ROOT_DIR = environ.Path(__file__) - 3  # ({{ cookiecutter.project_slug }}/config
 APPS_DIR = ROOT_DIR.path('{{ cookiecutter.project_slug }}')
 
 env = environ.Env()
-env.read_env()
+
+# Load operating system environment variables and then prepare to use them
+env = environ.Env()
+
+# .env file, should load only in development environment
+READ_DOT_ENV_FILE = env('DJANGO_READ_DOT_ENV_FILE', default=False)
+
+if READ_DOT_ENV_FILE:
+    # Operating System Environment variables have precende over variables defined in the .env file, 
+    # that is to say variables from the .env files will only be used if not defined
+    # as environment variables.
+    env_file = str(ROOT_DIR.path('.env'))
+    print('Loading : {}'.format(env_file))
+    env.read_env(env_file)
+    print('The .env file has been loaded. See common.py for more information')
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -24,7 +24,7 @@ env = environ.Env()
 READ_DOT_ENV_FILE = env('DJANGO_READ_DOT_ENV_FILE', default=False)
 
 if READ_DOT_ENV_FILE:
-    # Operating System Environment variables have precende over variables defined in the .env file, 
+    # Operating System Environment variables have precende over variables defined in the .env file,
     # that is to say variables from the .env files will only be used if not defined
     # as environment variables.
     env_file = str(ROOT_DIR.path('.env'))

--- a/{{cookiecutter.project_slug}}/env.example
+++ b/{{cookiecutter.project_slug}}/env.example
@@ -4,6 +4,7 @@ POSTGRES_PASSWORD=mysecretpass
 POSTGRES_USER=postgresuser
 
 # General settings
+# DJANGO_READ_DOT_ENV_FILE=True
 DJANGO_ADMIN_URL=
 DJANGO_SETTINGS_MODULE=config.settings.production
 DJANGO_SECRET_KEY=CHANGEME!!!


### PR DESCRIPTION
In the [current configuration](https://github.com/pydanny/cookiecutter-django/blob/de4c8c4012757aa544b68cae4904c0383b418bd9/%7B%7Bcookiecutter.project_slug%7D%7D/config/settings/common.py#L19), the `.env` file is being loaded by django and this has caused some problems (issues #944 #950 #1000 #1001 ). The `.env` file should be loaded only by Docker and in the production environment, the settings must be configured via the environment variable as define https://12factor.net/config . All available environment variables are listed at https://cookiecutter-django.readthedocs.io/en/latest/settings.html#settings.

However, in some cases, practicality beats purity, like in the development environment. 

To do this, optionally, the `.env` file can be read by Django by manually setting the environment variable on current command line shell (not on `.env` file):

```bash
export DJANGO_READ_DOT_ENV_FILE=True
```

> Note: Remember, never, under any circumstance, commit the `.env` file or equivalent in your git repository. This can introduce serious security breaches, because environment variables commonly contain privated information that should certainly never be public.