### PR TITLE
Look for .env file in root dir

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/common.py
+++ b/{{cookiecutter.project_slug}}/config/settings/common.py
@@ -16,7 +16,7 @@ ROOT_DIR = environ.Path(__file__) - 3  # ({{ cookiecutter.project_slug }}/config
 APPS_DIR = ROOT_DIR.path('{{ cookiecutter.project_slug }}')
 
 env = environ.Env()
-env.read_env()
+env.read_env(ROOT_DIR('.env'))
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Based on https://github.com/pydanny/cookiecutter-django/issues/490 and some other discussions.

Docker is looking for a .env file in root directory. But with the old code, django settings will expect the file in /config/settings directory. This change fixes this, so that django settings will look for .env file in the root directory.