### PR TITLE
Removed dependency of `watch` task and put it in runSequence 

### DIFF
--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -88,21 +88,17 @@ gulp.task('browserSync', function() {
     });
 });
 
-// Default task
-gulp.task('default', function() {
-    runSequence(['styles', 'scripts', 'imgCompression'], 'runServer', 'browserSync');
-});
-
-////////////////////////////////
-		//Watch//
-////////////////////////////////
-
 // Watch
-gulp.task('watch', ['default'], function() {
+gulp.task('watch', function() {
 
   gulp.watch(paths.sass + '/*.scss', ['styles']);
   gulp.watch(paths.js + '/*.js', ['scripts']).on("change", reload);
   gulp.watch(paths.images + '/*', ['imgCompression']);
   gulp.watch(paths.templates + '/**/*.html').on("change", reload);
 
+});
+
+// Default task
+gulp.task('default', function() {
+    runSequence(['styles', 'scripts', 'imgCompression'], 'runServer', 'browserSync', 'watch');
 });


### PR DESCRIPTION
There has been no runSequence for `watch` task, which makes it won’t be run.
This makes gulp can watch file changes and let them process (css compile, minify, image compress...) automatically.