### PR TITLE
ADDED: HTTPS is on by default

### DIFF
--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -37,6 +37,19 @@ root directory of this project as a starting point. Add your own variables to th
 file won't be tracked by git by default so you'll have to make sure to use some other mechanism to copy your secret if
 you are relying solely on git.
 
+HTTPS is on by default
+----------------------
+
+SSL (Secure Sockets Layer) is a standard security technology for establishing an encrypted link between a server and a client, typically in this case, a web server (website) and a browser. Not having HTTPS means that malicious network users can sniff authentication credentials between your website and end users' browser.
+
+It is always better to deploy a site behind HTTPS and will become crucial as the web services extend to the IoT (Internet of Things). For this reason, we have set up a number of security defaults to help make your website secure:
+
+* In the `.env.example`, we have made it simpler for you to change the default `Django Admin` into a custom name through an environmental variable. This should make it harder to guess the access to the admin panel.
+
+* If you are not using a subdomain of the domain name set in the project, then remember to put the your staging/production IP address in the  ``ALLOWED_HOSTS``_ environment variable before you deploy your website. Failure to do this will mean you will not have access to your website through the HTTP protocol.
+
+* Access to the Django admin is set up by default to require HTTPS in production or once *live*. We recommend that you look into setting up the *Certbot and Let's Encrypt Setup* mentioned below or another HTTPS certification service.
+
 Optional: nginx-proxy Setup
 ---------------------------
 
@@ -52,8 +65,7 @@ This pass all incoming requests on `nginx-proxy`_ to the nginx service your appl
 Optional: Postgres Data Volume Modifications
 ---------------------------------------------
 
-Postgres is saving its database files to the `postgres_data` volume by default. Change that if you wan't
-something else and make sure to make backups since this is not done automatically.
+Postgres is saving its database files to the `postgres_data` volume by default. Change that if you want something else and make sure to make backups since this is not done automatically.
 
 Optional: Certbot and Let's Encrypt Setup
 ------------------------------------------

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -73,6 +73,11 @@ To migrate your app and to create a superuser, run::
 
 Here we specify the ``django`` container as the location to run our management commands.
 
+Add your Docker development server IP
+------------------------------------
+
+When ``DEBUG`` is set to `True`, the host is validated against ``['localhost', '127.0.0.1', '[::1]']``. This is adequate when running a ``virtualenv``. For Docker, in the ``config.settings.local``, add your host development server IP to ``INTERNAL_IPS`` or ``ALLOWED_HOSTS`` if the variable exists.
+
 Production Mode
 ~~~~~~~~~~~~~~~
 

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -84,7 +84,7 @@ X_FRAME_OPTIONS = 'DENY'
 # SITE CONFIGURATION
 # ------------------------------------------------------------------------------
 # Hosts/domain names that are valid for this site
-# See https://docs.djangoproject.com/en/1.6/ref/settings/#allowed-hosts
+# See https://docs.djangoproject.com/en/1.10/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['{{cookiecutter.domain_name}}'])
 # END SITE CONFIGURATION
 


### PR DESCRIPTION
ADDED: HTTPS is on by default. This will give a new user an
understanding of the intention of Cookiecutter Django’s secure deployment in a production environment.