### PR TITLE
1029: Fix typo in Docker deployment docs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -107,6 +107,7 @@ Listed in alphabetical order.
   Lyla Fischer
   Martin Blech
   Mathijs Hoogland         `@MathijsHoogland`_
+  Matt Braymer-Hayes       `@mattayes`_                  @mattayes
   Matt Linares
   Matt Menzenski           `@menzenski`_
   Matt Warren              `@mfwarren`_
@@ -193,6 +194,7 @@ Listed in alphabetical order.
 .. _@knitatoms: https://github.com/knitatoms
 .. _@krzysztofzuraw: https://github.com/krzysztofzuraw
 .. _@MathijsHoogland: https://github.com/MathijsHoogland
+.. _@mattayes: https://github.com/mattayes
 .. _@menzenski: https://github.com/menzenski
 .. _@mfwarren: https://github.com/mfwarren
 .. _@mimischi: https://github.com/mimischi

--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -143,7 +143,7 @@ If you have errors, you can always check your stack with `docker-compose`. Switc
 Supervisor Example
 -------------------
 
-Once you are ready with your initial setup, you wan't to make sure that your application is run by a process manager to
+Once you are ready with your initial setup, you want to make sure that your application is run by a process manager to
 survive reboots and auto restarts in case of an error. You can use the process manager you are most familiar with. All
 it needs to do is to run `docker-compose up` in your projects root directory.
 


### PR DESCRIPTION
Hi folks:

This should fix #1029. Let me know how I can improve this!