### PR TITLE
Fix Docker test PyCharm Run Configurations settings file

### DIFF
--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___all.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___all.xml
@@ -4,7 +4,7 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
+      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
     <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___class__TestUser.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___class__TestUser.xml
@@ -4,7 +4,7 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
+      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
     <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___file__test_models.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___file__test_models.xml
@@ -4,7 +4,7 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
+      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
     <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___module__users.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___module__users.xml
@@ -4,7 +4,7 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
+      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
     <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___specific__test_get_absolute_url.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___specific__test_get_absolute_url.xml
@@ -4,7 +4,7 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
+      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
     <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />


### PR DESCRIPTION
For the time being, `DJANGO_SETTINGS_MODULE = config.settings.local` for any of the five PyCharm's Docker test Run Configurations provided along with the generated project. 

This PR fixes the issue switching `DJANGO_SETTINGS_MODULE` to be `config.settings.test`.