### PR TITLE
Fix pytest DJANGO_SETTINGS_MODULE

### DIFF
--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings.local
+DJANGO_SETTINGS_MODULE=config.settings.test


### PR DESCRIPTION
Switch from `DJANGO_SETTINGS_MODULE = config.settings.local` to `DJANGO_SETTINGS_MODULE = config.settings.test`.

This is to expand on and supplement #1031.