### PR TITLE
A few cleanups: 1) Fixed common.py references (now called base.py), 2…

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -50,7 +50,7 @@ Setup your email backend
 
 django-allauth sends an email to verify users (and superusers) after signup and login (if they are still not verified). To send email you need to `configure your email backend`_
 
-.. _configure your email backend: http://docs.djangoproject.com/en/1.9/topics/email/#smtp-backend
+.. _configure your email backend: https://docs.djangoproject.com/en/dev/topics/email/#smtp-backend
 
 In development you can (optionally) use MailHog_ for email testing. MailHog is built with Go so there are no dependencies. To use MailHog:
 

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -25,7 +25,7 @@ version [0.1.0]
     The starting version number for your project.
 
 timezone [UTC]
-    Used in the common settings file for the `TIME_ZONE` value.
+    Used in the base settings file for the `TIME_ZONE` value.
 
 use_whitenoise [y]
     Whether to use WhiteNoise_ for static file serving.

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, unicode_literals
 
 import environ
 
-ROOT_DIR = environ.Path(__file__) - 3  # ({{ cookiecutter.project_slug }}/config/settings/common.py - 3 = {{ cookiecutter.project_slug }}/)
+ROOT_DIR = environ.Path(__file__) - 3  # ({{ cookiecutter.project_slug }}/config/settings/base.py - 3 = {{ cookiecutter.project_slug }}/)
 APPS_DIR = ROOT_DIR.path('{{ cookiecutter.project_slug }}')
 
 # Load operating system environment variables and then prepare to use them
@@ -28,7 +28,7 @@ if READ_DOT_ENV_FILE:
     env_file = str(ROOT_DIR.path('.env'))
     print('Loading : {}'.format(env_file))
     env.read_env(env_file)
-    print('The .env file has been loaded. See common.py for more information')
+    print('The .env file has been loaded. See base.py for more information')
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -62,8 +62,8 @@ MIDDLEWARE = ['opbeat.contrib.django.middleware.OpbeatAPMMiddleware', ] + MIDDLE
 
 # SECURITY CONFIGURATION
 # ------------------------------------------------------------------------------
-# See https://docs.djangoproject.com/en/1.9/ref/middleware/#module-django.middleware.security
-# and https://docs.djangoproject.com/ja/1.9/howto/deployment/checklist/#run-manage-py-check-deploy
+# See https://docs.djangoproject.com/en/dev/ref/middleware/#module-django.middleware.security
+# and https://docs.djangoproject.com/en/dev/howto/deployment/checklist/#run-manage-py-check-deploy
 
 # set this to 60 seconds and then to 518400 when you can prove it works
 SECURE_HSTS_SECONDS = 60
@@ -82,7 +82,7 @@ X_FRAME_OPTIONS = 'DENY'
 # SITE CONFIGURATION
 # ------------------------------------------------------------------------------
 # Hosts/domain names that are valid for this site
-# See https://docs.djangoproject.com/en/1.10/ref/settings/#allowed-hosts
+# See https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['{{cookiecutter.domain_name}}', ])
 # END SITE CONFIGURATION
 
@@ -278,7 +278,7 @@ RAVEN_CONFIG = {
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
+# See https://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
     'version': 1,

--- a/{{cookiecutter.project_slug}}/docs/docker_ec2.rst
+++ b/{{cookiecutter.project_slug}}/docs/docker_ec2.rst
@@ -31,7 +31,7 @@ The Docker compose tool (previously known as `fig`_) makes linking these contain
         ...
     docker-compose.yml
 
-Each component of your application would get its own `Dockerfile`_. The rest of this example assumes you are using the `base postgres image`_ for your database. Your database settings in `config/common.py` might then look something like:
+Each component of your application would get its own `Dockerfile`_. The rest of this example assumes you are using the `base postgres image`_ for your database. Your database settings in `config/base.py` might then look something like:
 
 .. _Dockerfile: https://docs.docker.com/reference/builder/
 .. _base postgres image: https://registry.hub.docker.com/_/postgres/


### PR DESCRIPTION
…) Made URLs consistent in pointing to dev Django docs as well as https.