### PR TITLE
pycharm doc typo

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/pycharm/configuration.rst
+++ b/{{cookiecutter.project_slug}}/docs/pycharm/configuration.rst
@@ -14,7 +14,7 @@ This repository comes with already prepared "Run/Debug Configurations" for docke
 
 .. image:: images/2.png
 
-But as you can see, at the beggining there is something wrong with them. They have red X on django icon, and they cannot be used, withot configuring remote python interpteter. To do that, you have to go to *Settings > Build, Execution, Deployment* first.
+But as you can see, at the beggining there is something wrong with them. They have red X on django icon, and they cannot be used, without configuring remote python interpteter. To do that, you have to go to *Settings > Build, Execution, Deployment* first.
 
 
 Next, you have to add new remote python interpreter, based on already tested deployment settings. Go to *Settings > Project > Project Interpreter*. Click on the cog icon, and click *Add Remote*.


### PR DESCRIPTION
a very simple typo in the word without