### PR TITLE
Updated aws cache type to t2.micro

### DIFF
--- a/{{cookiecutter.project_slug}}/.ebextensions/20_elasticcache.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/20_elasticcache.config
@@ -24,7 +24,7 @@ Resources:
       CacheNodeType:
         Fn::GetOptionSetting:
           OptionName : "CacheNodeType"
-          DefaultValue : "cache.t1.micro"
+          DefaultValue : "cache.t2.micro"
       NumCacheNodes:
         Fn::GetOptionSetting:
           OptionName : "NumCacheNodes"

--- a/{{cookiecutter.project_slug}}/.ebextensions/30_options.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/30_options.config
@@ -1,6 +1,6 @@
 option_settings:
   "aws:elasticbeanstalk:customoption":
-    CacheNodeType : cache.t1.micro
+    CacheNodeType : cache.t2.micro
     NumCacheNodes : 1
     Engine : redis
     CachePort : 6379


### PR DESCRIPTION
The cache type which is currently used is now no longer (https://aws.amazon.com/elasticache/previous-generation/). Now the t2 nodes are meant to be both cheaper and better.
When deploying a new project to AWS this the creation failed and took hours of my life to debug and I hope it can help someone else :) 