### PR TITLE
Remove Webpack from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,8 +141,7 @@ Answer the prompts with your own desired options_. For example::
     Select js_task_runner:
     1 - Gulp
     2 - Grunt
-    3 - Webpack
-    4 - None
+    3 - None
     Choose from 1, 2, 3, 4 [1]: 1
     use_lets_encrypt [n]: n
     Select open_source_license:

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -74,8 +74,7 @@ js_task_runner [1]
 
     1. Gulp_
     2. Grunt_
-    3. Webpack_
-    4. None
+    3. None
 
 use_lets_encrypt [n]
     Use `Let's Encrypt`_ as the certificate authority for this project.


### PR DESCRIPTION
Support for webpack was dropped but seems to have stayed in docs. This cleans that up. 