### PR TITLE
Use """ instead of ''' in test settings module doctsring

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Test settings
 
 - Used to run tests fast on the continuous integration server and locally
-'''
+"""
 
 from .base import *  # noqa
 


### PR DESCRIPTION
Since all other settings modules define their docstrings with """...""" I guessed that we might want to do that too for the test settings module.