### PR TITLE
Use Argon2 password hashing algorithm by default

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -141,6 +141,7 @@ Listed in alphabetical order.
   Vitaly Babiy
   Vivian Guillen           `@viviangb`_
   Will Farley              `@goldhand`_                 @g01dhand
+  William Archinal         `@archinal`_
   Yaroslav Halchenko
 ========================== ============================ ==============
 
@@ -152,6 +153,7 @@ Listed in alphabetical order.
 .. _@amjith: https://github.com/amjith
 .. _@andor-pierdelacabeza: https://github.com/andor-pierdelacabeza
 .. _@antoniablair: https://github.com/antoniablair
+.. _@archinal: https://github.com/archinal
 .. _@areski: https://github.com/areski
 .. _@arruda: https://github.com/arruda
 .. _@bittner: https://github.com/bittner

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -213,6 +213,16 @@ ROOT_URLCONF = 'config.urls'
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#wsgi-application
 WSGI_APPLICATION = 'config.wsgi.application'
 
+# PASSWORD STORAGE SETTINGS
+# ------------------------------------------------------------------------------
+# See https://docs.djangoproject.com/en/dev/topics/auth/passwords/#using-argon2-with-django
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.BCryptPasswordHasher',
+]
 
 # PASSWORD VALIDATION
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -26,6 +26,9 @@ django-model-utils==2.6.1
 # Images
 Pillow==4.0.0
 
+# Password storage
+argon2-cffi==16.3.0
+
 # For user registration, either via email or social
 # Well-built with regular release cycles!
 django-allauth==0.31.0


### PR DESCRIPTION
As per the recommendation in the Django docs [here](https://docs.djangoproject.com/en/dev/topics/auth/passwords/#using-argon2-with-django) to use the argon2 password hashing algorithm, this pull request enables that hashing algorithm by default for users of cookiecutter-django.

I noticed that this change was discussed and approved in [this issue](https://github.com/pydanny/cookiecutter-django/issues/850), but the aforementioned pull request to implement it was never produced.