### PR TITLE
Workaround flake8 "imported but unused" errors

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -12,8 +12,6 @@ Local settings
 - Add django-extensions as app
 """
 
-import socket
-import os
 from .base import *  # noqa
 
 # DEBUG
@@ -55,6 +53,9 @@ INSTALLED_APPS += ['debug_toolbar', ]
 
 INTERNAL_IPS = ['127.0.0.1', '10.0.2.2', ]
 {% if cookiecutter.use_docker == 'y' %}
+{# [cookiecutter-django] This is a workaround to flake8 "imported but unused" errors #}
+import socket
+import os
 # tricks to have debug toolbar when developing with docker
 if os.environ.get('USE_DOCKER') == 'yes':
     ip = socket.gethostbyname(socket.gethostname())


### PR DESCRIPTION
Those have been arising here-and-there around a number of latest Travis CI builds.

Try #1 (hopefully, the last one)