### PR TITLE
Docs: add more info for docker production setup

### DIFF
--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -37,6 +37,13 @@ root directory of this project as a starting point. Add your own variables to th
 file won't be tracked by git by default so you'll have to make sure to use some other mechanism to copy your secret if
 you are relying solely on git.
 
+To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the `DJANGO_SENTRY_DSN` variable. This should be enough to report crashes to Sentry.
+
+You will probably also need to setup the Mail backend, for example by adding a `Mailgun`_ API key and a `Mailgun`_ sender domain, otherwise, the account creation view will crash and result in a 500 error when the backend attempts to send an email to the account owner.
+
+.. _sentry.io: https://sentry.io/welcome
+.. _Mailgun: https://mailgun.com
+
 HTTPS is on by default
 ----------------------
 


### PR DESCRIPTION
Missing .env variables can result in some functions crashing.