### PR TITLE
Require celery==3.1.24 instead of celery==4.0.2

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -51,7 +51,7 @@ django-redis==4.7.0
 redis>=2.10.5
 
 {% if cookiecutter.use_celery == "y" %}
-celery==4.0.2
+celery==3.1.24
 {% endif %}
 
 {% if cookiecutter.use_compressor == "y" %}


### PR DESCRIPTION
We're about to switch to `celery=4.0.2` [in the upcoming PR](https://github.com/pydanny/cookiecutter-django/pull/945).

Fixes #1139 