### PR TITLE
[Fix] #1173 Nginx SSL redirect loop

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
+++ b/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
@@ -83,6 +83,8 @@ http {
 
         # cookiecutter-django app
         location @proxy_to_app {
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Url-Scheme $scheme;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;


### PR DESCRIPTION
Headers not being passed was causing nginx to redirect to SSL again & again.