### PR TITLE
Add 'catch-all' server block to suppress Invalid HTTP_HOST exception

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
+++ b/{{cookiecutter.project_slug}}/compose/nginx/nginx-secure.conf
@@ -92,5 +92,14 @@ http {
         }
 
     }
-
+    
+    # catch-all block to prevent Invalid HTTP_HOST header exception
+    server {
+        listen       80  default_server;
+        listen       443 ssl default_server;
+        ssl_certificate /etc/letsencrypt/live/___my.example.com___/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/___my.example.com___/privkey.pem;
+        server_name  _;
+        return       444;
+    }
 }


### PR DESCRIPTION
Got Invalid HTTP_HOST exception in default configuation.
Add catch-all server block to suppress those suspicious requests.