### PR TITLE
Allow for dynamic bootstrap compilation

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -56,6 +56,7 @@ Listed in alphabetical order.
   Areski Belaid            `@areski`_
   Ashley Camba
   Barclay Gauld            `@yunti`_
+  Ben Warren               `@bwarren2`
   Ben Lopatin
   Benjamin Abel
   Bo Lopker                `@blopker`_

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -21,5 +21,6 @@
     "postgresql_version": ["9.6", "9.5", "9.4", "9.3", "9.2"],
     "js_task_runner": ["Gulp", "Grunt", "None"],
     "use_lets_encrypt": "n",
+    "custom_bootstrap_compilation": "n",
     "open_source_license": ["MIT", "BSD", "GPLv3", "Apache Software License 2.0", "Not open source"]
 }

--- a/{{cookiecutter.project_slug}}/Gruntfile.js
+++ b/{{cookiecutter.project_slug}}/Gruntfile.js
@@ -60,6 +60,9 @@ module.exports = function (grunt) {
       dev: {
           options: {
               outputStyle: 'nested',
+{% if cookiecutter.custom_bootstrap_compilation == 'y' %}
+              includePaths: ['bower_components/bootstrap-sass/assets/stylesheets/bootstrap/'],
+{% endif %}
               sourceMap: false,
               precision: 10
           },
@@ -70,6 +73,9 @@ module.exports = function (grunt) {
       dist: {
           options: {
               outputStyle: 'compressed',
+{% if cookiecutter.custom_bootstrap_compilation == 'y' %}
+              includePaths: ['bower_components/bootstrap-sass/assets/stylesheets/bootstrap/'],
+{% endif %}
               sourceMap: false,
               precision: 10
           },

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -145,3 +145,12 @@ See detailed `cookiecutter-django Elastic Beanstalk documentation`_.
 .. _`cookiecutter-django Docker documentation`: http://cookiecutter-django.readthedocs.io/en/latest/deployment-with-elastic-beanstalk.html
 
 {% endif %}
+{% if cookiecutter.custom_bootstrap_compilation == "y" %}
+Custom Bootstrap Compilation
+^^^^^^
+
+To get automatic Bootstrap recompilation with variables of your choice, install bootstrap sass (`bower install bootstrap-sass`) and tweak your variables in `static/sass/custom_bootstrap_vars`.
+
+(You can find a list of available variables [in the bootstrap-sass source](https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss), or get explanations on them in the [Bootstrap docs](https://getbootstrap.com/customize/).)
+
+{% endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/sass/project.scss
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/sass/project.scss
@@ -1,3 +1,57 @@
+{% if cookiecutter.custom_bootstrap_compilation == 'y' %}
+@import "variables";
+@import "custom_bootstrap_vars";
+@import "mixins";
+
+// Reset and dependencies
+@import "normalize";
+@import "print";
+@import "glyphicons";
+
+// Core CSS
+@import "scaffolding";
+@import "type";
+@import "code";
+@import "grid";
+@import "tables";
+@import "forms";
+@import "buttons";
+
+// Components
+@import "component-animations";
+@import "dropdowns";
+@import "button-groups";
+@import "input-groups";
+@import "navs";
+@import "navbar";
+@import "breadcrumbs";
+@import "pagination";
+@import "pager";
+@import "labels";
+@import "badges";
+@import "jumbotron";
+@import "thumbnails";
+@import "alerts";
+@import "progress-bars";
+@import "media";
+@import "list-group";
+@import "panels";
+@import "responsive-embed";
+@import "wells";
+@import "close";
+
+// Components w/ JavaScript
+@import "modals";
+@import "tooltip";
+@import "popovers";
+@import "carousel";
+
+// Utility classes
+@import "utilities";
+@import "responsive-utilities";
+{% endif %}
+
+
 
 // project specific CSS goes here
 


### PR DESCRIPTION
This makes Grunt automatically rebuild Bootstrap CSS with tweaked variables for custom styling.  

This is a gesture toward a feature PR; is it desirable in the base cookiecutter?   It feels a little kludgy to name everything in bootstrap, but that is the way I think it has to be done.

Potential necessary changes: adding some docs to the README with the option chosen, editing CONTRIBUTORS.