### PR TITLE
Updated pycharm run configurations to work as explained in the docs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -87,6 +87,7 @@ Listed in alphabetical order.
   Felipe Arruda            `@arruda`_
   Garry Cairns             `@garry-cairns`_
   Garry Polley             `@garrypolley`_
+  Hamish Durkin            `@durkode`_
   Harry Percival           `@hjwp`_
   Henrique G. G. Pereira   `@ikkebr`_
   Ian Lee                  `@IanLee1521`_
@@ -178,6 +179,7 @@ Listed in alphabetical order.
 .. _@dhepper: https://github.com/dhepper
 .. _@dot2dotseurat: https://github.com/dot2dotseurat
 .. _@dsclementsen: https://github.com/dsclementsen
+.. _@durkode: https://github.com/durkode
 .. _@epileptic-fish: https://gihub.com/epileptic-fish
 .. _@eraldo: https://github.com/eraldo
 .. _@eriol: https://github.com/eriol

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__migrate.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__migrate.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__runserver.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__runserver.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:django/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__runserver_plus.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__runserver_plus.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:django/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___all.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___all.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___class__TestUser.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___class__TestUser.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___file__test_models.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___file__test_models.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___module__users.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___module__users.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___specific__test_get_absolute_url.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___specific__test_get_absolute_url.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://$PROJECT_DIR$/dev.yml:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/dev.yml]:pycharm/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />


### PR DESCRIPTION
This pull request solves the invalid Docker run configurations in pycharm, as I raised in issue #1222 

It solves my issue on pycharm 2017.1.4. I am not knowledgable about the format of these xml files (and specifically why the square brackets made it work), so hopefully who knows more can review this. I arrived at this fix by manually configuring pycharm correctly and then comparing the difference with what cookiecutter-django generated

Closes #1222.