### PR TITLE
update heroku python runtime to 3.6.2

### DIFF
--- a/{{cookiecutter.project_slug}}/runtime.txt
+++ b/{{cookiecutter.project_slug}}/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.3
+python-3.6.2


### PR DESCRIPTION
Heroku now supports python-3.6.2
https://devcenter.heroku.com/articles/python-support#supported-runtimes