### PR TITLE
Introduce development-time Celery services

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/django/Dockerfile-dev
+++ b/{{cookiecutter.project_slug}}/compose/django/Dockerfile-dev
@@ -13,6 +13,14 @@ COPY ./compose/django/start-dev.sh /start-dev.sh
 RUN sed -i 's/\r//' /start-dev.sh
 RUN chmod +x /start-dev.sh
 
+COPY ./compose/django/celery/worker/start-dev.sh /start-celeryworker-dev.sh
+RUN sed -i 's/\r//' /start-celeryworker-dev.sh
+RUN chmod +x /start-celeryworker-dev.sh
+
+COPY ./compose/django/celery/beat/start-dev.sh /start-celerybeat-dev.sh
+RUN sed -i 's/\r//' /start-celerybeat-dev.sh
+RUN chmod +x /start-celerybeat-dev.sh
+
 WORKDIR /app
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/{{cookiecutter.project_slug}}/compose/django/celery/beat/start-dev.sh
+++ b/{{cookiecutter.project_slug}}/compose/django/celery/beat/start-dev.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+rm -f './celerybeat.pid'
+celery -A {{cookiecutter.project_slug}}.taskapp beat -l INFO

--- a/{{cookiecutter.project_slug}}/compose/django/celery/worker/start-dev.sh
+++ b/{{cookiecutter.project_slug}}/compose/django/celery/worker/start-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+celery -A {{cookiecutter.project_slug}}.taskapp worker -l INFO

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -5,7 +5,7 @@ volumes:
   postgres_backup_dev: {}
 
 services:
-  django:
+  django: &django
     build:
       context: .
       dockerfile: ./compose/django/Dockerfile-dev
@@ -28,7 +28,6 @@ services:
       - postgres_backup_dev:/backups
     environment:
       - POSTGRES_USER={{cookiecutter.project_slug}}
-
 {% if cookiecutter.use_pycharm == 'y' %}
   pycharm:
     build:
@@ -41,21 +40,19 @@ services:
     volumes:
       - .:/app
 {% endif %}
-
 {% if cookiecutter.use_mailhog == 'y' %}
   mailhog:
     image: mailhog/mailhog:v1.0.0
     ports:
       - "8025:8025"
 {% endif %}
-
-{% if cookiecutter.use_celery == 'y' -%}
+{% if cookiecutter.use_celery == 'y' %}
   redis:
-      image: redis:3.0
+    image: redis:3.0
 
   celeryworker:
-    extends:
-      service: django
+    # https://github.com/docker/compose/issues/3220
+    <<: *django
     depends_on:
       - redis
       - postgres{% if cookiecutter.use_mailhog == 'y' %}
@@ -63,11 +60,11 @@ services:
     command: /start-celeryworker-dev.sh
 
   celerybeat:
-    extends:
-      service: django
+    # https://github.com/docker/compose/issues/3220
+    <<: *django
     depends_on:
       - redis
       - postgres{% if cookiecutter.use_mailhog == 'y' %}
       - mailhog{% endif %}
     command: /start-celerybeat-dev.sh
-{%- endif %}
+{% endif %}

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -57,6 +57,7 @@ services:
       - redis
       - postgres{% if cookiecutter.use_mailhog == 'y' %}
       - mailhog{% endif %}
+    ports: []
     command: /start-celeryworker-dev.sh
 
   celerybeat:
@@ -66,5 +67,6 @@ services:
       - redis
       - postgres{% if cookiecutter.use_mailhog == 'y' %}
       - mailhog{% endif %}
+    ports: []
     command: /start-celerybeat-dev.sh
 {% endif %}

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -5,6 +5,22 @@ volumes:
   postgres_backup_dev: {}
 
 services:
+  django:
+    build:
+      context: .
+      dockerfile: ./compose/django/Dockerfile-dev
+    depends_on:
+      - postgres{% if cookiecutter.use_mailhog == 'y' %}
+      - mailhog{% endif %}
+    volumes:
+      - .:/app
+    environment:
+      - POSTGRES_USER={{cookiecutter.project_slug}}
+      - USE_DOCKER=yes
+    ports:
+      - "8000:8000"
+    command: /start-dev.sh
+
   postgres:
     build: ./compose/postgres
     volumes:
@@ -12,22 +28,6 @@ services:
       - postgres_backup_dev:/backups
     environment:
       - POSTGRES_USER={{cookiecutter.project_slug}}
-
-  django:
-    build:
-      context: .
-      dockerfile: ./compose/django/Dockerfile-dev
-    command: /start-dev.sh
-    depends_on:
-      - postgres{% if cookiecutter.use_mailhog == 'y' %}
-      - mailhog{% endif %}
-    environment:
-      - POSTGRES_USER={{cookiecutter.project_slug}}
-      - USE_DOCKER=yes
-    volumes:
-      - .:/app
-    ports:
-      - "8000:8000"
 
 {% if cookiecutter.use_pycharm == 'y' %}
   pycharm:
@@ -48,3 +48,26 @@ services:
     ports:
       - "8025:8025"
 {% endif %}
+
+{% if cookiecutter.use_celery == 'y' -%}
+  redis:
+      image: redis:3.0
+
+  celeryworker:
+    extends:
+      service: django
+    depends_on:
+      - redis
+      - postgres{% if cookiecutter.use_mailhog == 'y' %}
+      - mailhog{% endif %}
+    command: /start-celeryworker-dev.sh
+
+  celerybeat:
+    extends:
+      service: django
+    depends_on:
+      - redis
+      - postgres{% if cookiecutter.use_mailhog == 'y' %}
+      - mailhog{% endif %}
+    command: /start-celerybeat-dev.sh
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -5,13 +5,6 @@ volumes:
   postgres_backup: {}
 
 services:
-  postgres:
-    build: ./compose/postgres
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - postgres_backup:/backups
-    env_file: .env
-
   django:
     build:
       context: .
@@ -20,6 +13,13 @@ services:
       - postgres
       - redis
     command: /gunicorn.sh
+    env_file: .env
+
+  postgres:
+    build: ./compose/postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - postgres_backup:/backups
     env_file: .env
 
   nginx:


### PR DESCRIPTION
This one also addresses a proposal on keeping dependent services DRY made in #1255.

* [x] Introduce `celeryworker`, `celerybeat`, and `redis` services to `local.yml` the DRY way.
* [x] Test changeset locally.

Closes #1225.