### PR TITLE
Fix docs erros/typos

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -59,6 +59,7 @@ Listed in alphabetical order.
   Ben Warren               `@bwarren2`
   Ben Lopatin
   Benjamin Abel
+  Bert de Miranda          `@bertdemiranda`_
   Bo Lopker                `@blopker`_
   Bouke Haarsma
   Brent Payne              `@brentpayne`_               @brentpayne

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -59,7 +59,7 @@ You can also set the environment variable ``COMPOSE_FILE`` pointing to ``local.y
 
 And then run::
 
-    $ docker-compose -f production.yml up
+    $ docker-compose up
 
 Running management commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -65,7 +65,7 @@ Running management commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As with any shell command that we wish to run in our container, this is done
-using the ``docker-compose -f production.yml run`` command.
+using the ``docker-compose -f local.yml run`` command.
 
 To migrate your app and to create a superuser, run::
 


### PR DESCRIPTION
1. [x] [Boot the System: "And then run: $ docker-compose -f production.yml up" to "And then run: $ docker-compose up"](https://cookiecutter-django.readthedocs.io/en/latest/developing-locally-docker.html#boot-the-system).
1. [x] [Running management commands: "docker-compose -f production.yml run" to "docker-compose -f local.yml run'](https://cookiecutter-django.readthedocs.io/en/latest/developing-locally-docker.html#running-management-commands).
1. [x] Merge in #1242 designating @bertdemiranda as a contributor.

Closes #1263.