### PR TITLE
Add tota11y to base.html

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -100,6 +100,10 @@
       <script src="{% static 'js/project.js' %}"></script>
       {% endraw %}{% if cookiecutter.use_compressor == "y" %}{% raw %}{% endcompress %}{% endraw %}{% endif %}{% raw %}
 
+      {% if debug %}
+            <script src="https://cdn.rawgit.com/Khan/tota11y/ce0d19ed/build/tota11y.min.js"></script>
+      {% endif %}
+
     {% endblock javascript %}
   </body>
 </html>


### PR DESCRIPTION
Hello,

I suggest add tota11y to base.html. It's toolbar like ```django-debug-toolbar```, but for accessibility. tota11y helps visualize how site performs with assistive technologies.
Caring for people with disabilities is important and should be a standard feature in producing high quality websites, so it is advisable to provide the tools that support this process.