### PR TITLE
Remove django-braces requirement

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -16,7 +16,6 @@ whitenoise==3.3.0
 
 
 # Forms
-django-braces==1.11.0
 django-crispy-forms==1.6.1
 
 # Models


### PR DESCRIPTION
Equivalent functionality is already in Django 1.9+:
https://docs.djangoproject.com/en/1.11/releases/1.9/#permission-mixins-for-class-based-views

Looks like cookiecutter-django converted to the Django 1.9+ mixins a while back:
https://github.com/pydanny/cookiecutter-django/blob/master/CHANGELOG.md#changed-37
