### PR TITLE
Added Whitelist for /compose/local/ based on issue #1321

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -361,3 +361,9 @@ mailhog
 {% endif %}
 
 {{ cookiecutter.project_slug }}/media/
+
+{% if cookiecutter.use_docker == 'y' -%}
+# Added to maintain local compose files which are ignored by something above.
+# See issue https://github.com/pydanny/cookiecutter-django/issues/1321
+!/compose/local/
+{% endif %}


### PR DESCRIPTION
Something in the file above ignores the /compose/local directory, which is not an expected pattern. Barring a reasonable explanation or modification of the above rules, this whitelists that folder. See issue #1321.