### PR TITLE
Change pep 8 for pycodestyle in docs and project requirements

### DIFF
--- a/docs/linters.rst
+++ b/docs/linters.rst
@@ -30,14 +30,14 @@ The config for pylint is located in .pylintrc. It specifies:
 * Disable linting messages for missing docstring and invalid name
 * max-parents=13
 
-pep8
+pycodestyle
 -----
 
 This is included in flake8's checks, but you can also run it separately to see a more detailed report:
 
-    $ pep8 <python files that you wish to lint>
+    $ pycodestyle <python files that you wish to lint>
 
-The config for pep8 is located in setup.cfg. It specifies:
+The config for pycodestyle is located in setup.cfg. It specifies:
 
 * Set max line length to 120 chars
 * Exclude ``.tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules``

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ binaryornot==0.4.4
 
 # Testing
 pytest==3.2.2
-pep8==1.7.0
+pycodestyle==2.3.1
 pyflakes==1.6.0
 tox==2.8.2
 pytest-cookies==0.2.0


### PR DESCRIPTION
- Some little changes to the documentation
- Update the requirement in the project  requirements (I think that pyup didn't catch the rename of the package.)