### PR TITLE
Fix anymail v1.0 change to EmailBackend

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -159,7 +159,7 @@ ANYMAIL = {
     'MAILGUN_API_KEY': env('DJANGO_MAILGUN_API_KEY'),
     'MAILGUN_SENDER_DOMAIN': env('MAILGUN_SENDER_DOMAIN')
 }
-EMAIL_BACKEND = 'anymail.backends.mailgun.MailgunBackend'
+EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
 
 # TEMPLATE CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
from https://github.com/anymail/django-anymail/releases
> There are no new breaking changes in the 1.0 release, but a breaking change introduced several months ago in v0.8 is now strictly enforced. If you still have an EMAIL_BACKEND setting that looks like "anymail.backends.espname.EspNameBackend", you'll need to change it to just "anymail.backends.espname.EmailBackend". (Earlier versions had issued a DeprecationWarning. See the v0.8 release notes.)