### PR TITLE
Fix MediaRootS3BotoStorage: do not override existing files

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -126,6 +126,7 @@ Listed in alphabetical order.
   mozillazg                `@mozillazg`_
   Pablo                    `@oubiga`_
   Parbhat Puri             `@parbhat`_
+  Pierre Chiquet           `@pchiquet`_
   Peter Bittner            `@bittner`_
   Raphael Pierzina         `@hackebrot`_
   Raony Guimarães Corrêa   `@raonyguimaraes`_

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -126,8 +126,8 @@ Listed in alphabetical order.
   mozillazg                `@mozillazg`_
   Pablo                    `@oubiga`_
   Parbhat Puri             `@parbhat`_
-  Pierre Chiquet           `@pchiquet`_
   Peter Bittner            `@bittner`_
+  Pierre Chiquet           `@pchiquet`_
   Raphael Pierzina         `@hackebrot`_
   Raony Guimarães Corrêa   `@raonyguimaraes`_
   Reggie Riser             `@reggieriser`_

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -120,7 +120,7 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 #  See:http://stackoverflow.com/questions/10390244/
 from storages.backends.s3boto3 import S3Boto3Storage
 StaticRootS3BotoStorage = lambda: S3Boto3Storage(location='static')  # noqa
-MediaRootS3BotoStorage = lambda: S3Boto3Storage(location='media')  # noqa
+MediaRootS3BotoStorage = lambda: S3Boto3Storage(location='media', file_overwrite=False)  # noqa
 DEFAULT_FILE_STORAGE = 'config.settings.production.MediaRootS3BotoStorage'
 
 MEDIA_URL = 'https://s3.amazonaws.com/%s/media/' % AWS_STORAGE_BUCKET_NAME


### PR DESCRIPTION
see https://github.com/jschneier/django-storages/issues/50

The default settings is AWS_S3_FILE_OVERWRITE = True. This makes sense for static files but not for media files.
see https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings