### PR TITLE
[Elastic Beanstalk] Adding createsuperuser container command

### DIFF
--- a/{{cookiecutter.project_slug}}/.ebextensions/40_python.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/40_python.config
@@ -4,6 +4,9 @@ container_commands:
     leader_only: True
   02_collectstatic:
     command: "source /opt/python/run/venv/bin/activate && python manage.py collectstatic --noinput"
+  03_createsuperuser:
+    command: "(echo \"import os\"; echo \"from django.contrib.auth import get_user_model\"; echo \"UserModel = get_user_model()\"; echo \"if not UserModel._default_manager.filter(username='admin').exists(): UserModel._default_manager.create_superuser(**dict(username='admin',email='admin@example.com',password=os.environ['SECRET_KEY'][:8]));\") | django-admin.py shell"
+    leader_only: True
 option_settings:
   "aws:elasticbeanstalk:application:environment":
     DJANGO_SETTINGS_MODULE: "config.settings.production"


### PR DESCRIPTION
This PR adds a simple command to map the django-admin's createsuperuser in production for EB.

It uses first 8 digits of the environment variable `DJANGO_SECRET_KEY` as the default password.

Credits to: https://github.com/wolfg1969/elastic-beanstalk-nginx-uwsgi-django