### PR TITLE
Fixed old Docker service name in PyCharm run configurations

### DIFF
--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__migrate.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__migrate.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___all.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___all.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___class__TestUser.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___class__TestUser.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___file__test_models.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___file__test_models.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___module__users.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___module__users.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___specific__test_get_absolute_url.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/Docker__tests___specific__test_get_absolute_url.xml
@@ -6,7 +6,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="config.settings.test" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:pycharm/python" />
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/local.yml]:django/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />


### PR DESCRIPTION
The old "pycharm" service was removed from as part of #1307 but some of the PyCharm run configurations still refer to it.  This PR updates them to point to the remaining "django" service.