### PR TITLE
Fix duplicated and missing links in README

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -79,16 +79,12 @@ Email Server
 {% if cookiecutter.use_docker == 'y' %}
 In development, it is often nice to be able to see emails that are being sent from your application. For that reason local SMTP server `MailHog`_ with a web interface is available as docker container.
 
-.. _mailhog: https://github.com/mailhog/MailHog
-
 Container mailhog will start automatically when you will run all docker containers.
 Please check `cookiecutter-django Docker documentation`_ for more details how to start all containers.
 
 With MailHog running, to view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
 {% else %}
 In development, it is often nice to be able to see emails that are being sent from your application. If you choose to use `MailHog`_ when generating the project a local SMTP server with a web interface will be available.
-
-.. _mailhog: https://github.com/mailhog/MailHog
 
 To start the service, make sure you have nodejs installed, and then type the following::
 
@@ -101,6 +97,7 @@ To view messages that are sent by your application, open your browser and go to 
 
 The email server will exit when you exit the Grunt task on the CLI with Ctrl+C.
 {% endif %}
+.. _mailhog: https://github.com/mailhog/MailHog
 {% endif %}
 {% if cookiecutter.use_sentry_for_error_reporting == "y" %}
 
@@ -142,7 +139,7 @@ Elastic Beanstalk
 
 See detailed `cookiecutter-django Elastic Beanstalk documentation`_.
 
-.. _`cookiecutter-django Docker documentation`: http://cookiecutter-django.readthedocs.io/en/latest/deployment-with-elastic-beanstalk.html
+.. _`cookiecutter-django Elastic Beanstalk documentation`: http://cookiecutter-django.readthedocs.io/en/latest/deployment-with-elastic-beanstalk.html
 
 {% endif %}
 {% if cookiecutter.custom_bootstrap_compilation == "y" %}


### PR DESCRIPTION
- Fix missing RST target 'cookiecutter-django Elastic Beanstalk documentation' instead of redefining 'cookiecutter-django Docker documentation'
- Avoid duplication of 'mailhog' link