### PR TITLE
Fixed old docker-compose filenames

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -129,7 +129,7 @@ def remove_docker_files():
     """
     Removes files needed for docker if it isn't going to be used
     """
-    for filename in ["dev.yml", "docker-compose.yml", ".dockerignore"]:
+    for filename in ["local.yml", "production.yml", ".dockerignore"]:
         filename = os.path.join(PROJECT_DIRECTORY, filename)
         if os.path.exists(filename):
             os.remove(filename)


### PR DESCRIPTION
The post-generation hook references the old docker-compose filenames of `dev.yml` and `docker-compose.yml` when cleaning up files in a non-Docker project.  Those files were renamed a while back to `local.yml` and `production.yml`.  See related commit e69ceebfc584373bfec446033dd1de2fa48560fe.