### PR TITLE
Fixes wsgi.py app_path to avoid deleting all /config occurrences.

### DIFF
--- a/{{cookiecutter.project_slug}}/config/wsgi.py
+++ b/{{cookiecutter.project_slug}}/config/wsgi.py
@@ -20,7 +20,8 @@ from django.core.wsgi import get_wsgi_application
 
 # This allows easy placement of apps within the interior
 # {{ cookiecutter.project_slug }} directory.
-app_path = os.path.dirname(os.path.abspath(__file__)).replace('/config', '')
+app_path = os.path.abspath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir))
 sys.path.append(os.path.join(app_path, '{{ cookiecutter.project_slug }}'))
 
 {% if cookiecutter.use_sentry_for_error_reporting == 'y' -%}


### PR DESCRIPTION
Fixes #1466 using parent directory instead of replacing /config in app_path.