### PR TITLE
Update pytest-sugar to 0.9.1

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/test.txt
+++ b/{{cookiecutter.project_slug}}/requirements/test.txt
@@ -15,4 +15,4 @@ django-coverage-plugin==1.5.0
 
 # pytest
 pytest-django==3.1.2
-pytest-sugar==0.9.0
+pytest-sugar==0.9.1


### PR DESCRIPTION
This version fixes the incompatibility issue with pytest 3.4.0.
https://github.com/Frozenball/pytest-sugar/pull/133

I have tested this with one project.

Closes #1472.