### PR TITLE
Add Debian 9 (Stretch) os dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/utility/requirements-stretch.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-stretch.apt
@@ -1,0 +1,23 @@
+##basic build dependencies of various Django apps for Debian Jessie 9.x
+#build-essential metapackage install: make, gcc, g++,
+build-essential
+#required to translate
+gettext
+python3-dev
+
+##shared dependencies of:
+##Pillow, pylibmc
+zlib1g-dev
+
+##Postgresql and psycopg2 dependencies
+libpq-dev
+
+##Pillow dependencies
+libtiff5-dev
+libjpeg62-turbo-dev
+libfreetype6-dev
+liblcms2-dev
+libwebp-dev
+
+##django-extensions
+graphviz-dev


### PR DESCRIPTION
They are properly checked and all of them are the same than version 8, but due to it is necessary to have an specific file, here it is.