### PR TITLE
Use the default docker from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,6 @@ env:
     - TOX_ENV=py36
 
 before_install:
-  - sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-precise main" > /etc/apt/sources.list.d/docker.list'
-  - sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-  - sudo apt-get update
-  - sudo apt-key update
-  - sudo apt-get --force-yes -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine=1.11.1-0~precise
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   - docker-compose -v
   - docker -v
 


### PR DESCRIPTION
Rather than installing a specific version and having to update it ourselves, we can now use the [default from Travis](https://docs.travis-ci.com/user/docker/). Current versions are:
- Docker 17.09-ce
- Docker compose 1.17.1

Fixes #1199 