### PR TITLE
Install psycopg2 with --no-binary option

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -36,7 +36,7 @@ django-allauth==0.35.0
 # from http://www.lfd.uci.edu/~gohlke/pythonlibs/#psycopg
 {% else %}
 # Python-PostgreSQL Database Adapter
-psycopg2==2.7.4
+psycopg2==2.7.4 --no-binary psycopg2
 {%- endif %}
 
 # Unicode slugification

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -6,7 +6,7 @@
 # Python-PostgreSQL Database Adapter
 # Assuming Windows is used locally, and *nix -- in production.
 # ------------------------------------------------------------
-psycopg2==2.7.4
+psycopg2==2.7.4 --no-binary psycopg2
 {%- endif %}
 
 # WSGI Handler


### PR DESCRIPTION
http://initd.org/psycopg/docs/install.html#disabling-wheel-packages-for-psycopg-2-7

Disable installing psycopg2 from binary to prepare for 2.8 release. There is no binaries for Alpine if/when we switch in #498 