### PR TITLE
Remove AWS S3 header bytes workaround

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -103,12 +103,8 @@ AWS_QUERYSTRING_AUTH = False
 # AWS cache settings, don't change unless you know what you're doing:
 AWS_EXPIRY = 60 * 60 * 24 * 7
 
-# TODO See: https://github.com/jschneier/django-storages/issues/47
-# Revert the following and use str after the above-mentioned bug is fixed in
-# either django-storage-redux or boto
-control = 'max-age=%d, s-maxage=%d, must-revalidate' % (AWS_EXPIRY, AWS_EXPIRY)
 AWS_S3_OBJECT_PARAMETERS = {
-    'CacheControl': bytes(control, encoding='latin-1'),
+    'CacheControl': 'max-age=%d, s-maxage=%d, must-revalidate' % (AWS_EXPIRY, AWS_EXPIRY),
 }
 
 # URL that handles the media served from MEDIA_ROOT, used for managing


### PR DESCRIPTION
#1374 introduced the new `AWS_S3_OBJECT_PARAMETERS ` header but did not remove the bytes workaround.

This PR does the same.