### PR TITLE
Link to unminified CSS if using django-compressor

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -22,7 +22,7 @@
     <!-- Your stuff: Third-party CSS libraries go here -->
     {% endraw %}{% if cookiecutter.use_compressor == "y" %}{% raw %}{% compress css %}{% endraw %}{% endif %}{% raw %}
     <!-- This file stores project-specific CSS -->
-    {% endraw %}{% if cookiecutter.js_task_runner == "Gulp" %}{% raw %}
+    {% endraw %}{% if cookiecutter.js_task_runner == "Gulp" and cookiecutter.use_compressor == "n" %}{% raw %}
     <link href="{% static 'css/project.min.css' %}" rel="stylesheet">
     {% endraw %}{% else %}{% raw %}
     <link href="{% static 'css/project.css' %}" rel="stylesheet">


### PR DESCRIPTION
Fixes #1527 

Can be tested by running:
```
cookiecutter https://github.com/browniebroke/cookiecutter-django --checkout bug-500-compressor
```

@AntoineGagnon 