### PR TITLE
Celery config - json serialization by default

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -44,6 +44,7 @@ Listed in alphabetical order.
   Aaron Eikenberry         `@aeikenberry`_
   Adam Bogdał              `@bogdal`_
   Adam Dobrawy             `@ad-m`_
+  Adam Steele              `@adammsteele`
   Agam Dua
   Alberto Sanchez          `@alb3rto`_
   Alex Tsai                `@caffodian`_
@@ -159,6 +160,7 @@ Listed in alphabetical order.
 
 .. _@a7p: https://github.com/a7p
 .. _@ad-m: https://github.com/ad-m
+.. _@adammsteele: https://github.com/adammsteele
 .. _@aeikenberry: https://github.com/aeikenberry
 .. _@alb3rto: https://github.com/alb3rto
 .. _@ameistad: https://github.com/ameistad

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -274,6 +274,10 @@ if CELERY_BROKER_URL == 'django://':
     CELERY_RESULT_BACKEND = 'redis://'
 else:
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+# default to json serialization only
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
 ########## END CELERY
 {% endif %}
 


### PR DESCRIPTION
This PR will by default set celery up to only allow json serialization of messages.  

This should solve the problem reported here #1304 in a safe way, as well as transition to celery 4 default configuration values.