### PR TITLE
update grunt-sass to latest version

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -89,6 +89,7 @@ Listed in alphabetical order.
   Dong Huynh               `@trungdong`_
   Emanuel Calso            `@bloodpet`_                  @bloodpet
   Eraldo Energy            `@eraldo`_
+  Eric Groom               `@ericgroom`_
   Eyad Al Sibai            `@eyadsibai`_
   Felipe Arruda            `@arruda`_
   Garry Cairns             `@garry-cairns`_

--- a/docs/live-reloading-and-sass-compilation.rst
+++ b/docs/live-reloading-and-sass-compilation.rst
@@ -15,7 +15,7 @@ If you don't already have it, install `compass` (doesn't hurt if you run this co
 
 Now you just need::
 
-    $ grunt serve
+    $ npm run dev
 
 The base app will now run as it would with the usual ``manage.py runserver`` but with live reloading and Sass compilation enabled.
 

--- a/{{cookiecutter.project_slug}}/Gruntfile.js
+++ b/{{cookiecutter.project_slug}}/Gruntfile.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
 
         processors: [
           require('pixrem')(), // add fallbacks for rem units
-          require('autoprefixer-core')({browsers: [
+          require('autoprefixer')({browsers: [
             'Android 2.3',
             'Android >= 4',
             'Chrome >= 20',

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -52,5 +52,13 @@
   },
   "engines": {
     "node": ">=0.8.0"
+  },
+  "scripts": {
+    {% if cookiecutter.js_task_runner == 'Grunt' %}
+    "dev": "grunt serve"
+    {% elif cookiecutter.js_task_runner == 'Gulp' %}
+    "dev": "gulp"
+    {% endif %}
+
   }
 }

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -4,22 +4,22 @@
   "dependencies": {},
   "devDependencies": {
     {% if cookiecutter.js_task_runner == 'Grunt' %}
-    "autoprefixer-core": "~5.2.1",
+    "autoprefixer": "~8.1.0",
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
     "bootstrap": "^4.0.0",
     {% endif %}
-    "connect-livereload": "~0.3.2",
-    "cssnano": "~2.1.0",
-    "grunt": "~0.4.5",
+    "connect-livereload": "~0.6.0",
+    "cssnano": "~3.10.0",
+    "grunt": "~1.0.2",
     "grunt-bg-shell": "~2.3.1",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-postcss": "~0.5.5",
+    "grunt-contrib-watch": "~1.0.0",
+    "grunt-postcss": "~0.9.0",
     "grunt-sass": "~2.1.0",
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
     "jquery": "^3.2.1-slim",
     {% endif %}
     "load-grunt-tasks": "~3.2.0",
-    "pixrem": "~1.3.1",
+    "pixrem": "~4.0.1",
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
     "popper.js": "^1.12.3",
     {% endif %}

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -14,7 +14,7 @@
     "grunt-bg-shell": "~2.3.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-postcss": "~0.5.5",
-    "grunt-sass": "~1.0.0",
+    "grunt-sass": "~2.1.0",
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
     "jquery": "^3.2.1-slim",
     {% endif %}

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -31,23 +31,23 @@
     "browser-sync": "^2.14.0",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^3.1.1",
+    "gulp-autoprefixer": "^5.0.0",
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
     "gulp-concat": "^2.6.1",
     {% endif %}
     "gulp-cssnano": "^2.1.2",
-    "gulp-imagemin": "^3.0.3",
+    "gulp-imagemin": "^4.1.0",
     "gulp-pixrem": "^1.0.0",
     "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.3.2",
-    "gulp-uglify": "^2.0.0",
+    "gulp-sass": "^3.1.0",
+    "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.7",
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
     "jquery": "^3.2.1-slim",
     "popper.js": "^1.12.3",
     {% endif %}
-    "run-sequence": "^1.2.2"
+    "run-sequence": "^2.1.1"
     {% endif %}
   },
   "engines": {


### PR DESCRIPTION
I was having issues installing grunt-sass running `npm install` which was failing on installing a dependency: 'node-sass'. I noticed that it was trying to install a really old version of node-sass so I tried installing the latest version of `grunt-sass` in an empty project which fixed the issue. I haven't done any extensive testing but the latest version of `grunt-sass` seems to work fine and all of the tox tests pass (although I'm not totally sure if they test grunt). I noticed some of the other dependencies in package.json are outdated, so hopefully this pull request can be the start of updating those if needed.