### PR TITLE
Install psycopg2-binary when not using docker locally

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -8,11 +8,6 @@ argon2-cffi==18.1.0  # https://github.com/hynek/argon2_cffi
 {%- if cookiecutter.use_whitenoise == 'y' %}
 whitenoise==3.3.1  # https://github.com/evansd/whitenoise
 {%- endif %}
-{%- if cookiecutter.windows == 'y' %}
-# TODO: On Windows, install psycopg2 manually from http://www.lfd.uci.edu/~gohlke/pythonlibs/#psycopg
-{%- else %}
-psycopg2==2.7.4 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
-{%- endif %}
 redis>=2.10.5  # https://github.com/antirez/redis
 {%- if cookiecutter.use_celery == "y" %}
 celery==3.1.25  # pyup: <4.0  # https://github.com/celery/celery

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -3,6 +3,11 @@
 Werkzeug==0.14.1  # https://github.com/pallets/werkzeug
 ipdb==0.11  # https://github.com/gotcha/ipdb
 Sphinx==1.7.1  # https://github.com/sphinx-doc/sphinx
+{%- if cookiecutter.use_docker == 'y' %}
+psycopg2==2.7.4 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
+{%- else %}
+psycopg2-binary==2.7.4  # https://github.com/psycopg/psycopg2
+{%- endif %}
 
 # Testing
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -5,6 +5,7 @@
 gevent==1.2.2
 gunicorn==19.7.1  # https://github.com/benoitc/gunicorn
 boto3==1.6.2  # pyup: update minor  # https://github.com/boto/boto3
+psycopg2==2.7.4 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 {%- if cookiecutter.use_whitenoise == 'n' %}
 Collectfast==0.6.0  # https://github.com/antonagestam/collectfast
 {%- endif %}


### PR DESCRIPTION
Fixes #1530 

- The binary package should be installable on Windows locally, as [they provide wheels](https://pypi.python.org/pypi/psycopg2-binary) for Windows.
- The binary package [is not recommended for Production](https://github.com/psycopg/psycopg2#installation), so compile from source:
  > The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources.
- Fixes an issue we have currently if one chooses `use_windows = 'y'`: psycopg2 isn't installed at all. This should be resolved by this PR.