### PR TITLE
Celery code blocks are still generated even though Celery is not opted out for

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -254,6 +254,11 @@ def remove_celery_envs():
     os.remove(os.path.join('.envs', '.production', '.celery'))
 
 
+def remove_celery_compose_dirs():
+    shutil.rmtree(os.path.join('compose', 'local', 'django', 'celery'))
+    shutil.rmtree(os.path.join('compose', 'production', 'django', 'celery'))
+
+
 def main():
     postgres_user = generate_postgres_user()
     set_flags_in_envs(postgres_user)
@@ -318,6 +323,7 @@ def main():
         remove_celery_app()
         if '{{ cookiecutter.use_docker }}'.lower() == 'y':
             remove_celery_envs()
+            remove_celery_compose_dirs()
 
     if '{{ cookiecutter.use_travisci }}'.lower() == 'n':
         remove_dottravisyml_file()

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -62,8 +62,10 @@ target/
 # pyenv
 .python-version
 
+{% if cookiecutter.use_celery == 'y' -%}
 # celery beat schedule file
 celerybeat-schedule
+{%- endif %}
 
 # Environments
 .venv

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
   # https://docs.djangoproject.com/en/2.0/ref/django-admin/#dbshell
   && apk add postgresql-client
 
-# Requirements have to be pulled and installed here, otherwise caching won't work
+# Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
 RUN pip install -r /requirements/local.txt
 

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -26,7 +26,7 @@ RUN chmod +x /entrypoint.sh
 COPY ./compose/local/django/start.sh /start.sh
 RUN sed -i 's/\r//' /start.sh
 RUN chmod +x /start.sh
-
+{% if cookiecutter.use_celery == "y" %}
 COPY ./compose/local/django/celery/worker/start.sh /start-celeryworker.sh
 RUN sed -i 's/\r//' /start-celeryworker.sh
 RUN chmod +x /start-celeryworker.sh
@@ -34,7 +34,7 @@ RUN chmod +x /start-celeryworker.sh
 COPY ./compose/local/django/celery/beat/start.sh /start-celerybeat.sh
 RUN sed -i 's/\r//' /start-celerybeat.sh
 RUN chmod +x /start-celerybeat.sh
-
+{% endif %}
 WORKDIR /app
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -28,7 +28,7 @@ COPY ./compose/production/django/entrypoint.sh /entrypoint.sh
 RUN sed -i 's/\r//' /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN chown django /entrypoint.sh
-
+{% if cookiecutter.use_celery == "y" %}
 COPY ./compose/production/django/celery/worker/start.sh /start-celeryworker.sh
 RUN sed -i 's/\r//' /start-celeryworker.sh
 RUN chmod +x /start-celeryworker.sh
@@ -36,7 +36,7 @@ RUN chmod +x /start-celeryworker.sh
 COPY ./compose/production/django/celery/beat/start.sh /start-celerybeat.sh
 RUN sed -i 's/\r//' /start-celerybeat.sh
 RUN chmod +x /start-celerybeat.sh
-
+{% endif %}
 COPY . /app
 
 RUN chown -R django /app

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update \
 RUN addgroup -S django \
     && adduser -S -G django django
 
-# Requirements have to be pulled and installed here, otherwise caching won't work
+# Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
 RUN pip install --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements


### PR DESCRIPTION
* `cookiecutter.use_celery == "y"` jinja conditions in
    * [ ] `.gitignore`;
    * [ ] `compose/local/django/Dockerfile`;
    * [ ] `compose/production/django/Dockerfile`.
* conditionally remove the following through `hooks/post_gen_project.py`:
    * [ ] `compose/local/django/celery/`;
    * [ ] `compose/production/django/celery/`.

Closes  #1388.