### PR TITLE
Removed unnecessary/misleading configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -237,8 +237,7 @@ LOGGING = {
 
 SENTRY_CELERY_LOGLEVEL = env.int('DJANGO_SENTRY_LOG_LEVEL', logging.INFO)
 RAVEN_CONFIG = {
-    'CELERY_LOGLEVEL': env.int('DJANGO_SENTRY_LOG_LEVEL', logging.INFO),
-    'DSN': SENTRY_DSN
+    'dsn': SENTRY_DSN
 }
 {%- else %}
 # LOGGING

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/taskapp/celery.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/taskapp/celery.py
@@ -41,7 +41,7 @@ class CeleryConfig(AppConfig):
             # @formatter:on
 {%- endif %}
 
-            raven_client = RavenClient(dsn=settings.RAVEN_CONFIG['DSN'])
+            raven_client = RavenClient(dsn=settings.RAVEN_CONFIG['dsn'])
             raven_register_logger_signal(raven_client)
             raven_register_signal(raven_client)
         {%- endif %}


### PR DESCRIPTION
`CELERY_LOGLEVEL` is a duplicate of `SENTRY_CELERY_LOGLEVEL`

the `DSN` is also a duplicate of `SENTRY_DSN`. and it should be lowercase `dsn` not uppercase.

Which means the `RAVEN_CONFIG` shouldn't even exist for `cookie-cutter` since most of the settings are already defined with the `SENTRY_*` variables.