### PR TITLE
Use Heroku's Release Phase for Migrations

### DIFF
--- a/{{cookiecutter.project_slug}}/Procfile
+++ b/{{cookiecutter.project_slug}}/Procfile
@@ -1,3 +1,4 @@
+release: ./manage.py migrate
 web: gunicorn config.wsgi:application
 {% if cookiecutter.use_celery == "y" -%}
 worker: celery worker --app={{cookiecutter.project_slug}}.taskapp --loglevel=info


### PR DESCRIPTION
Automatically run migrations on deployments to Heroku. Advantages include deployments are rolled-back if a migration fails, preventing broken applications due to failed migrations, no time between when application is released and database is migrated, and removes risk of forgetting to manually run migrations.