### PR TITLE
Update deployment-on-heroku.rst

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -33,7 +33,6 @@ Run these commands to deploy the project to Heroku:
     heroku config:set PYTHONHASHSEED=random
 
     git push heroku master
-    heroku run python manage.py migrate
     heroku run python manage.py check --deploy
     heroku run python manage.py createsuperuser
     heroku open


### PR DESCRIPTION
`heroku python manage.py migrate` no longer necessary, since it's now run by the release process in the Procfile. Related to https://github.com/pydanny/cookiecutter-django/pull/1615