### PR TITLE
making django_extensions as a base requirement and base installed apps.

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -73,6 +73,7 @@ THIRD_PARTY_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'rest_framework',
+    'django_extensions'
 ]
 LOCAL_APPS = [
     '{{ cookiecutter.project_slug }}.users.apps.UsersConfig',

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -71,7 +71,6 @@ if env('USE_DOCKER') == 'yes':
 # django-extensions
 # ------------------------------------------------------------------------------
 # https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration
-INSTALLED_APPS += ['django_extensions']  # noqa F405
 {% if cookiecutter.use_celery == 'y' -%}
 
 # Celery

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -20,6 +20,7 @@ django-environ==0.4.4  # https://github.com/joke2k/django-environ
 django-model-utils==3.1.2  # https://github.com/jazzband/django-model-utils
 django-allauth==0.36.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.7.2  # https://github.com/django-crispy-forms/django-crispy-forms
+django-extensions==2.0.7  # https://github.com/django-extensions/django-extensions
 {%- if cookiecutter.use_compressor == "y" %}
 django-compressor==2.2  # https://github.com/django-compressor/django-compressor
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -25,6 +25,5 @@ factory-boy==2.11.1  # https://github.com/FactoryBoy/factory_boy
 django-test-plus==1.0.22  # https://github.com/revsys/django-test-plus
 
 django-debug-toolbar==1.9.1  # https://github.com/jazzband/django-debug-toolbar
-django-extensions==2.0.7  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==1.5.0  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==3.2.1  # https://github.com/pytest-dev/pytest-django


### PR DESCRIPTION
Stuff breaks when you are giving flexibility of using "django_extensions" in local environment but not in production env. 


For example using docker system (uses base+local requirements ): 

`from django_extensions.db.models import TimeStampedModel`  would work.

but using docker in production mode will use (base + production requirements)
But production requirements file does not have "django_extensions".

Also typically I don't see why django_extensions should not be allowed in production environment. 
Am I missing anything there? 