### PR TITLE
Upgrade Caddy to 0.11 and pin its version to minor rather than patch

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/caddy/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/caddy/Dockerfile
@@ -1,3 +1,3 @@
-FROM abiosoft/caddy:0.10.6
+FROM abiosoft/caddy:0.11
 
 COPY ./compose/production/caddy/Caddyfile /etc/Caddyfile


### PR DESCRIPTION
* [x] Upgrade Caddy to [0.11](https://hub.docker.com/r/abiosoft/caddy/).
* [x] Pin Caddy version to minor rather than patch.