### PR TITLE
Remove openssl to fix conflict with libressl

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update \
   # Pillow dependencies
   && apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \
   # CFFI dependencies
-  && apk add libffi-dev openssl-dev py-cffi \
+  && apk add libffi-dev py-cffi \
   # Translations dependencies
   && apk add gettext \
   # https://docs.djangoproject.com/en/dev/ref/django-admin/#dbshell


### PR DESCRIPTION
The build is currently failing with the following error:

```
ERROR: unsatisfiable constraints:
  openssl-dev-1.0.2o-r0:
    conflicts:
               libressl-dev-2.6.3-r0[pc:libcrypto=1.0.2o]
               libressl-dev-2.6.3-r0[pc:libssl=1.0.2o]
               libressl-dev-2.6.3-r0[pc:openssl=1.0.2o]
    satisfies: world[openssl-dev]
  libressl-dev-2.6.3-r0:
    conflicts:
               openssl-dev-1.0.2o-r0[pc:libcrypto=2.6.3]
               openssl-dev-1.0.2o-r0[pc:libssl=2.6.3]
               openssl-dev-1.0.2o-r0[pc:openssl=2.6.3]
    satisfies:
               postgresql-dev-10.4-r0[libressl-dev]
```

It seems to be due to a conflict between `openssl` and `libressl`. We do not directly depend on `libressl` so we cannot remove it easily, but we can remove `openssl` from the Docker image to fix the problem.