### PR TITLE
Rename DJANGO_SENTRY_DSN env to SENTRY_DSN

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -14,26 +14,31 @@ Run these commands to deploy the project to Heroku:
     heroku pg:promote DATABASE_URL
 
     heroku addons:create heroku-redis:hobby-dev
-    heroku addons:create mailgun
 
-    heroku config:set WEB_CONCURRENCY=4
-    # Generating a 32 character-long random string without any of the visually similiar characters "IOl01":
-    heroku config:set DJANGO_ADMIN_URL="$(openssl rand -base64 4096 | tr -dc 'A-HJ-NP-Za-km-z2-9' | head -c 32)/"
-    heroku config:set DJANGO_SECRET_KEY="$(openssl rand -base64 64)"
-    heroku config:set DJANGO_SETTINGS_MODULE=config.settings.production
-    heroku config:set DJANGO_ALLOWED_HOSTS='.herokuapp.com'
+    # If using mailgun:
+    heroku addons:create mailgun:starter
 
-    heroku config:set DJANGO_AWS_ACCESS_KEY_ID=YOUR_AWS_ID_HERE
-    heroku config:set DJANGO_AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY_HERE
-    heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME=YOUR_AWS_S3_BUCKET_NAME_HERE
-
-    # This is to be set only if you're using Sentry:
-    heroku config:set DJANGO_SENTRY_DSN=YOUR_SENTRY_DSN
+    heroku addons:create sentry:f1
 
     heroku config:set PYTHONHASHSEED=random
+    heroku config:set WEB_CONCURRENCY=4
+    heroku config:set DJANGO_DEBUG=False
+    heroku config:set DJANGO_SETTINGS_MODULE=config.settings.production
+    heroku config:set DJANGO_SECRET_KEY="$(openssl rand -base64 64)"
+    # Generating a 32 character-long random string without any of the visually similiar characters "IOl01":
+    heroku config:set DJANGO_ADMIN_URL="$(openssl rand -base64 4096 | tr -dc 'A-HJ-NP-Za-km-z2-9' | head -c 32)/"
+    heroku config:set DJANGO_ALLOWED_HOSTS=  # Set this to your Heroku app url, e.g. 'bionic-beaver-28392.herokuapp.com'
+
+    heroku config:set DJANGO_AWS_ACCESS_KEY_ID=  # Assign with AWS_ACCESS_KEY_ID
+    heroku config:set DJANGO_AWS_SECRET_ACCESS_KEY=  # Assign with AWS_SECRET_ACCESS_KEY
+    heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME=  # Assign with AWS_STORAGE_BUCKET_NAME
 
     git push heroku master
+
     heroku run python manage.py migrate
-    heroku run python manage.py check --deploy
     heroku run python manage.py createsuperuser
+    heroku run python manage.py collectstatic --no-input
+
+    heroku run python manage.py check --deploy
+
     heroku open

--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -32,7 +32,7 @@ Configuring the Stack
 
 The majority of services above are configured through the use of environment variables. Just check out :ref:`envs` and you will know the drill.
 
-To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``DJANGO_SENTRY_DSN`` variable.
+To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable.
 
 You will probably also need to setup the Mail backend, for example by adding a `Mailgun`_ API key and a `Mailgun`_ sender domain, otherwise, the account creation view will crash and result in a 500 error when the backend attempts to send an email to the account owner.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -44,7 +44,7 @@ Environment Variable                    Django Setting              Development 
 DJANGO_AWS_ACCESS_KEY_ID                AWS_ACCESS_KEY_ID           n/a                                            raises error
 DJANGO_AWS_SECRET_ACCESS_KEY            AWS_SECRET_ACCESS_KEY       n/a                                            raises error
 DJANGO_AWS_STORAGE_BUCKET_NAME          AWS_STORAGE_BUCKET_NAME     n/a                                            raises error
-DJANGO_SENTRY_DSN                       SENTRY_DSN                  n/a                                            raises error
+SENTRY_DSN                              SENTRY_DSN                  n/a                                            raises error
 DJANGO_SENTRY_CLIENT                    SENTRY_CLIENT               n/a                                            raven.contrib.django.raven_compat.DjangoClient
 DJANGO_SENTRY_LOG_LEVEL                 SENTRY_LOG_LEVEL            n/a                                            logging.INFO
 MAILGUN_API_KEY                         MAILGUN_ACCESS_KEY          n/a                                            raises error

--- a/{{cookiecutter.project_slug}}/.envs/.production/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.production/.django
@@ -37,7 +37,7 @@ WEB_CONCURRENCY=4
 {% if cookiecutter.use_sentry == 'y' %}
 # Sentry
 # ------------------------------------------------------------------------------
-DJANGO_SENTRY_DSN=
+SENTRY_DSN=
 {% endif %}
 
 # Redis

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -187,7 +187,7 @@ MIDDLEWARE = ['raven.contrib.django.raven_compat.middleware.SentryResponseErrorI
 
 # Sentry
 # ------------------------------------------------------------------------------
-SENTRY_DSN = env('DJANGO_SENTRY_DSN')
+SENTRY_DSN = env('SENTRY_DSN')
 SENTRY_CLIENT = env('DJANGO_SENTRY_CLIENT', default='raven.contrib.django.raven_compat.DjangoClient')
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Rationale: so that Heroku auto-provisioned Sentry addon, with its `SENTRY_DSN` config var is being connected to out-of-box