### PR TITLE
Extend & enhance Celery configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -230,12 +230,9 @@ MANAGERS = ADMINS
 # ------------------------------------------------------------------------------
 INSTALLED_APPS += ['{{cookiecutter.project_slug}}.taskapp.celery.CeleryAppConfig']
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env('CELERY_BROKER_URL', default='django://')
+CELERY_BROKER_URL = env('CELERY_BROKER_URL')
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
-if CELERY_BROKER_URL == 'django://':
-    CELERY_RESULT_BACKEND = 'redis://'
-else:
-    CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ['json']
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_serializer

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -244,10 +244,10 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-time-limit
 # TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_TIME_LIMIT = 5 * 60
+CELERYD_TASK_TIME_LIMIT = 5 * 60
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-soft-time-limit
 # TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_SOFT_TIME_LIMIT = 60
+CELERYD_TASK_SOFT_TIME_LIMIT = 60
 
 {%- endif %}
 # django-allauth

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -245,6 +245,9 @@ CELERY_RESULT_SERIALIZER = 'json'
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-time-limit
 # TODO: set to whatever value is adequate in your circumstances
 CELERY_TASK_TIME_LIMIT = 5 * 60
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-soft-time-limit
+# TODO: set to whatever value is adequate in your circumstances
+CELERY_TASK_SOFT_TIME_LIMIT = 60
 
 {%- endif %}
 # django-allauth

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -229,6 +229,9 @@ MANAGERS = ADMINS
 # Celery
 # ------------------------------------------------------------------------------
 INSTALLED_APPS += ['{{cookiecutter.project_slug}}.taskapp.celery.CeleryAppConfig']
+if USE_TZ:
+    # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-timezone
+    CELERY_TIMEZONE = TIME_ZONE
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
 CELERY_BROKER_URL = env('CELERY_BROKER_URL')
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -242,6 +242,9 @@ CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_serializer
 CELERY_RESULT_SERIALIZER = 'json'
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-time-limit
+# TODO: set to whatever value is adequate in your circumstances
+CELERY_TASK_TIME_LIMIT = 5 * 60
 
 {%- endif %}
 # django-allauth

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -77,7 +77,7 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 # Celery
 # ------------------------------------------------------------------------------
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_always_eager
-CELERY_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = True
 
 {%- endif %}
 # Your stuff...

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -76,8 +76,10 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 
 # Celery
 # ------------------------------------------------------------------------------
-# http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_always_eager
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-always-eager
 CELERY_TASK_ALWAYS_EAGER = True
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-eager-propagates
+CELERY_EAGER_PROPAGATES = CELERY_TASK_ALWAYS_EAGER
 
 {%- endif %}
 # Your stuff...

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -79,7 +79,7 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-always-eager
 CELERY_TASK_ALWAYS_EAGER = True
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-eager-propagates
-CELERY_EAGER_PROPAGATES = CELERY_TASK_ALWAYS_EAGER
+CELERY_TASK_EAGER_PROPAGATES = True
 
 {%- endif %}
 # Your stuff...


### PR DESCRIPTION
[Celery **4.2**](https://github.com/pydanny/cookiecutter-django/pull/1446) is a [necessary](https://github.com/celery/celery/issues/4341) prerequisite for this PR.

* [x] `CELERYD_TASK_TIME_LIMIT`
* [x] `CELERYD_TASK_SOFT_TIME_LIMIT`
* [x] Rename `CELERY_ALWAYS_EAGER` to `CELERY_TASK_ALWAYS_EAGER`
* [x] Set `CELERY_TASK_EAGER_PROPAGATES = True` as by @browniebroke's suggestion
* [x] `CELERY_RESULT_BACKEND = CELERY_BROKER_URL` always
* [x] `CELERY_TIMEZONE = TIME_ZONE` given `USE_TZ` as by @browniebroke [suggestion](https://github.com/pydanny/cookiecutter-django/pull/1446#pullrequestreview-127518828)
* Flower's [soon to be integrated](https://github.com/pydanny/cookiecutter-django/pull/1655) as well
* ? (IMO, nice to have it by default but we also can leave a # TODO: ... in the `celeryworker` `start` script) [-Ofair](http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-o)
* ? (shouldn't be enabled by default, IMO, yet we could leave a "best practice" comment somewhere in the code base) [custom retry delay](http://docs.celeryproject.org/en/latest/userguide/tasks.html#using-a-custom-retry-delay) + [Automatic retry for known exceptions](http://docs.celeryproject.org/en/latest/userguide/tasks.html#automatic-retry-for-known-exceptions) using [exponential backoffs](http://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.retry_backoff)
