### PR TITLE
Remove entry from .gitignore causing compose/local to match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,7 +215,6 @@ tags
 [Ii]nclude
 [Ll]ib
 [Ll]ib64
-[Ll]ocal
 [Ss]cripts
 pyvenv.cfg
 pip-selfcheck.json


### PR DESCRIPTION
## Description

Not sure why this line was part of the `.gitignore`, but it causes the folder `{{cookiecutter.project_slug}}/compose/local` to match. This may cause partial commits when its content gets added.
