### PR TITLE
 Make 'duplicate_username' message translatable

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -162,6 +162,7 @@ Listed in alphabetical order.
   Will Farley              `@goldhand`_                 @g01dhand
   William Archinal         `@archinal`_
   Yaroslav Halchenko
+  Denis Bobrov             `@delneg`_       
 ========================== ============================ ==============
 
 .. _@a7p: https://github.com/a7p
@@ -265,7 +266,7 @@ Listed in alphabetical order.
 .. _@brentpayne: https://github.com/brentpayne
 .. _@afrowave: https://github.com/afrowave
 .. _@pchiquet: https://github.com/pchiquet
-
+.. _@delneg: https://github.com/delneg
 Special Thanks
 ~~~~~~~~~~~~~~
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -5,6 +5,7 @@ from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from .models import User
 from django.utils.translation import ugettext_lazy as _
 
+
 class MyUserChangeForm(UserChangeForm):
 
     class Meta(UserChangeForm.Meta):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from .models import User
-
+from django.utils.translation import ugettext_lazy as _
 
 class MyUserChangeForm(UserChangeForm):
 
@@ -14,7 +14,7 @@ class MyUserChangeForm(UserChangeForm):
 class MyUserCreationForm(UserCreationForm):
 
     error_message = UserCreationForm.error_messages.update(
-        {"duplicate_username": "This username has already been taken."}
+        {"duplicate_username": _("This username has already been taken.")}
     )
 
     class Meta(UserCreationForm.Meta):


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Added ugettext_lazy and used it on the 'duplicate_username' message




## Rationale

[//]: # (Why does the project need that?)
Other parts of the projects use ugettext_lazy, but this didn't




