### PR TITLE
remove inline comments of on heroku tutorial

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -21,17 +21,27 @@ Run these commands to deploy the project to Heroku:
     heroku addons:create sentry:f1
 
     heroku config:set PYTHONHASHSEED=random
+    
     heroku config:set WEB_CONCURRENCY=4
+    
     heroku config:set DJANGO_DEBUG=False
     heroku config:set DJANGO_SETTINGS_MODULE=config.settings.production
     heroku config:set DJANGO_SECRET_KEY="$(openssl rand -base64 64)"
+    
     # Generating a 32 character-long random string without any of the visually similiar characters "IOl01":
     heroku config:set DJANGO_ADMIN_URL="$(openssl rand -base64 4096 | tr -dc 'A-HJ-NP-Za-km-z2-9' | head -c 32)/"
-    heroku config:set DJANGO_ALLOWED_HOSTS=  # Set this to your Heroku app url, e.g. 'bionic-beaver-28392.herokuapp.com'
-
-    heroku config:set DJANGO_AWS_ACCESS_KEY_ID=  # Assign with AWS_ACCESS_KEY_ID
-    heroku config:set DJANGO_AWS_SECRET_ACCESS_KEY=  # Assign with AWS_SECRET_ACCESS_KEY
-    heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME=  # Assign with AWS_STORAGE_BUCKET_NAME
+    
+    # Set this to your Heroku app url, e.g. 'bionic-beaver-28392.herokuapp.com'
+    heroku config:set DJANGO_ALLOWED_HOSTS=
+    
+    # Assign with AWS_ACCESS_KEY_ID
+    heroku config:set DJANGO_AWS_ACCESS_KEY_ID=
+    
+    # Assign with AWS_SECRET_ACCESS_KEY
+    heroku config:set DJANGO_AWS_SECRET_ACCESS_KEY=
+    
+    # Assign with AWS_STORAGE_BUCKET_NAME
+    heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME=
 
     git push heroku master
 


### PR DESCRIPTION
I was helping a friend, to debug a error in a heroku app.
I discovered, he filled in the variables, but not removed the comments, and for some reason, the variables were submitted to heroku with the comments as part of the contents of the variable.

remove the inline comment from the documentation, you should prevent others from falling into the same error.
