### PR TITLE
Update test coverage command to use py.test.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -105,6 +105,7 @@ Listed in alphabetical order.
   Jan Van Bruggen          `@jvanbrug`_
   Jens Nilsson             `@phiberjenz`_
   Jimmy Gitonga            `@afrowave`_                  @afrowave
+  John Cass                `@jcass77`_                   @cass_john
   Julien Almarcha          `@sladinji`_
   Julio Castillo           `@juliocc`_
   Kaido Kert               `@kaidokert`_
@@ -164,7 +165,7 @@ Listed in alphabetical order.
   Will Farley              `@goldhand`_                 @g01dhand
   William Archinal         `@archinal`_
   Yaroslav Halchenko
-  Denis Bobrov             `@delneg`_       
+  Denis Bobrov             `@delneg`_
 ========================== ============================ ==============
 
 .. _@a7p: https://github.com/a7p

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -37,7 +37,7 @@ Test coverage
 
 To run the tests, check your test coverage, and generate an HTML coverage report::
 
-    $ coverage run manage.py test
+    $ coverage run -m pytest
     $ coverage html
     $ open htmlcov/index.html
 


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Update test coverage command in README to make use of ``py.test`` instead of ``manage.py test``.



## Rationale

[//]: # (Why does the project need that?)

cookiecutter-django seems to [prefer ``py.test``](https://github.com/pydanny/cookiecutter-django/blame/master/%7B%7Bcookiecutter.project_slug%7D%7D/README.rst#L44-L49) over the standard Django test utility, so it is a little confusing that the README does not also suggest using ``coverage`` in this way.

In addition, running ``coverage run manage.py test`` as suggested will raise an exception if the user does not first set ``TEMPLATES[0]["OPTIONS"]["debug"] = True`` in [test.py](https://github.com/pydanny/cookiecutter-django/blob/95ee1f159ddaf481192e49235738785d1bfb8427/%7B%7Bcookiecutter.project_slug%7D%7D/config/settings/test.py#L34):

```Creating test database for alias 'default'...
Coverage.py warning: Disabling plug-in 'django_coverage_plugin.DjangoTemplatePlugin' due to an exception:
Traceback (most recent call last):
  File "/Users/jcass/.virtualenvs/atrade_backend/lib/python3.6/site-packages/coverage/control.py", line 505, in _should_trace_internal
    file_tracer = plugin.file_tracer(canonical)
  File "/Users/jcass/.virtualenvs/atrade_backend/lib/python3.6/site-packages/django_coverage_plugin/plugin.py", line 157, in file_tracer
    self.debug_checked = check_debug()
  File "/Users/jcass/.virtualenvs/atrade_backend/lib/python3.6/site-packages/django_coverage_plugin/plugin.py", line 74, in check_debug
    "Template debugging must be enabled in settings."
django_coverage_plugin.plugin.DjangoTemplatePluginException: Template debugging must be enabled in settings.
System check identified no issues (0 silenced).```
