### PR TITLE
Add note about using keep_local_envs_in_vcs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -89,6 +89,7 @@ Listed in alphabetical order.
   Delio Castillo           `@jangeador`_                 @jangeador
   Denis Orehovsky          `@apirobot`_
   Dónal Adams              `@epileptic-fish`_
+  Diane Chen               `@purplediane`_               @purplediane88
   Dong Huynh               `@trungdong`_
   Emanuel Calso            `@bloodpet`_                  @bloodpet
   Eraldo Energy            `@eraldo`_
@@ -272,6 +273,7 @@ Listed in alphabetical order.
 .. _@afrowave: https://github.com/afrowave
 .. _@pchiquet: https://github.com/pchiquet
 .. _@delneg: https://github.com/delneg
+.. _@purplediane: https://github.com/purplediane
 Special Thanks
 ~~~~~~~~~~~~~~
 

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -93,7 +93,8 @@ use_travisci:
 keep_local_envs_in_vcs:
     Indicates whether the project's ``.envs/.local/`` should be kept in VCS
     (comes in handy when working in teams where local environment reproducibility
-    is strongly encouraged).
+    is strongly encouraged). 
+    Note: .env(s) are only utilized when Docker Compose and/or Heroku support is enabled.
 
 debug:
     Indicates whether the project should be configured for debugging.


### PR DESCRIPTION

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Add a note that the `keep_local_envs_in_vcs` only makes sense when using Docker or Heroku.

## Rationale

[//]: # (Why does the project need that?)
As a newbie, I wasn't sure about `keep_local_envs_in_vcs`, so I said yes, and when CC was building, it gave me the message: 
"[INFO]: .env(s) are only utilized when Docker Compose and/or Heroku support is enabled so keeping them does not make sense given your current setup." 
Seems like it could go in this documentation, and make things easier for newbies.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


