### PR TITLE
Set a default value for CELERY_BROKER_URL locally

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -234,7 +234,7 @@ if USE_TZ:
     CELERY_TIMEZONE = TIME_ZONE
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
 {% if cookiecutter.use_docker == 'y' -%}
-CELERY_BROKER_URL = env('CELERY_BROKER_URL')
+CELERY_BROKER_URL = env('CELERY_BROKER_URL', default="redis://redis:6379/0")
 {%- else %}
 CELERY_BROKER_URL = env('CELERY_BROKER_URL', default="redis://localhost:6379")
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -233,7 +233,12 @@ if USE_TZ:
     # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
+{% if cookiecutter.use_docker == 'y' -%}
 CELERY_BROKER_URL = env('CELERY_BROKER_URL')
+{%- else %}
+CELERY_BROKER_URL = env('CELERY_BROKER_URL', default="redis://localhost:6379")
+{%- endif %}
+
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -234,7 +234,7 @@ if USE_TZ:
     CELERY_TIMEZONE = TIME_ZONE
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
 {% if cookiecutter.use_docker == 'y' -%}
-CELERY_BROKER_URL = env('CELERY_BROKER_URL', default="redis://redis:6379/0")
+CELERY_BROKER_URL = env('CELERY_BROKER_URL')
 {%- else %}
 CELERY_BROKER_URL = env('CELERY_BROKER_URL', default="redis://localhost:6379")
 {%- endif %}


### PR DESCRIPTION
## Description

Set a default value for the environment variable `CELERY_BROKER_URL` to fix #1741.

## Rationale

When not using Docker, trying to generate or run migration crashes with an unrelated, confusing, error. 

We shouldn't need a default value in Docker as it's set by the whole setup, but in case something falls over with the generated `.env` files, we might see it again.

## Use case(s) / visualization(s)

When generating a project with `use_docker=n` and `use_celery=y`, trying to run migrations related commands crashes. Trying to run test exposes a `KeyError` related to that environment variable. 