### PR TITLE
Update bug issue template to ask to include the replay file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -17,7 +17,5 @@ about: Report a bug
 
 [//]: # (Any or all of the following:)
 [//]: # (* Host system configuration: OS, Docker & friends' versions etc.)
-[//]: # (* Project generation options)
+[//]: # (* Replay file https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html)
 [//]: # (* Logs)
-
-


### PR DESCRIPTION
Often, users report issues due to a specific combination of options, which required to get them. The current way is inefficient for users as well as maintainers:

- The user needs to copy/paste a terminal output, which might be gone if they closed the window
- Maintainer needs to regenerate with the same options
- Maintainer needs to be careful to bypass their potential profile defaults
- In case of error to one question, needs to re-generate

Cookiecutter has got a replay feature for about 3 years now, which seems like a more automated way to get the options from the user.

This updates the issue template for bugs report using this.