### PR TITLE
Add supported default for CELERY_BROKER_URL

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -158,6 +158,7 @@ Listed in alphabetical order.
   Taylor Baldwin
   Théo Segonds             `@show0k`_
   Tim Freund               `@timfreund`_
+  Tim Godfrey              `@timmygee`_
   Tom Atkins               `@knitatoms`_
   Tom Offermann
   Travis McNeill           `@Travistock`_               @tavistock_esq

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -233,7 +233,7 @@ if USE_TZ:
     # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env('CELERY_BROKER_URL')
+CELERY_BROKER_URL = env('CELERY_BROKER_URL', default='amqp://')
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

The correct default for `CELERY_BROKER_URL` on celery 4.2 is `amqp://`. `cookiecutter-django` is currently setting this as a blank string

## Rationale

[//]: # (Why does the project need that?)

Running `./manage.py runserver` on fresh install of cookiecutter-django results in the error

```
Traceback (most recent call last):
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/environ/environ.py", line 273, in get_value
    value = self.ENVIRON[var]
  File "/Users/tim/.virtualenvs/all_in/bin/../lib/python3.6/os.py", line 669, in __getitem__
    raise KeyError(key) from None
KeyError: 'CELERY_BROKER_URL'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./manage.py", line 30, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/core/management/__init__.py", line 371, in execute_from_command_line
    utility.execute()
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/core/management/__init__.py", line 365, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/core/management/commands/runserver.py", line 61, in execute
    super().execute(*args, **options)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/core/management/base.py", line 335, in execute
    output = self.handle(*args, **options)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/core/management/commands/runserver.py", line 70, in handle
    if not settings.DEBUG and not settings.ALLOWED_HOSTS:
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/conf/__init__.py", line 56, in __getattr__
    self._setup(name)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/conf/__init__.py", line 43, in _setup
    self._wrapped = Settings(settings_module)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/django/conf/__init__.py", line 106, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/tim/dev/allout/all_in/config/settings/local.py", line 1, in <module>
    from .base import *  # noqa
  File "/Users/tim/dev/allout/all_in/config/settings/base.py", line 230, in <module>
    CELERY_BROKER_URL = env('CELERY_BROKER_URL')
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/environ/environ.py", line 123, in __call__
    return self.get_value(var, cast=cast, default=default, parse_default=parse_default)
  File "/Users/tim/.virtualenvs/all_in/lib/python3.6/site-packages/environ/environ.py", line 277, in get_value
    raise ImproperlyConfigured(error_msg)
django.core.exceptions.ImproperlyConfigured: Set the CELERY_BROKER_URL environment variable
```

http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url states that the default is `amqp://`. I am guessing with the environment variable unset the default is getting passed in as a blank string, causing the error.

I realise there is another PR (#1748) addressing this but I'm not sure the solution there is as appropriate

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

Following the getting started instructions https://cookiecutter-django.readthedocs.io/en/latest/developing-locally.html#setting-up-development-environment with a fresh install of the cookiecutter template will result in an error without adding something to the local environment.