### PR TITLE
Cleanup outdated references to Grunt & Compass

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Features
 * Optimized development and production settings
 * Registration via django-allauth_
 * Comes with custom user model ready to go
-* Grunt build for compass and livereload
+* Optional custom static build using Gulp and livereload
 * Send emails via Anymail_ (using Mailgun_ by default, but switchable)
 * Media storage using Amazon S3
 * Docker support using docker-compose_ for development and production (using Caddy_ with LetsEncrypt_ support)
@@ -178,10 +178,9 @@ Answer the prompts with your own desired options_. For example::
     7 - 9.3
     Choose from 1, 2, 3, 4 [1]: 1
     Select js_task_runner:
-    1 - Gulp
-    2 - Grunt
-    3 - None
-    Choose from 1, 2, 3, 4 [1]: 1
+    1 - None
+    2 - Gulp
+    Choose from 1, 2 [1]: 1
     custom_bootstrap_compilation [n]: n
     Select open_source_license:
     1 - MIT

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -69,7 +69,7 @@ For instance, one of the packages we depend upon, ``django-allauth`` sends verif
 
 Now you have your own mail server running locally, ready to receive whatever you send it.
 
-.. _MailHog: https://github.com/mailhog/MailHog/
+.. _`Download the latest MailHog release`: https://github.com/mailhog/MailHog/releases
 .. _`properly configured`: https://docs.djangoproject.com/en/dev/topics/email/#smtp-backend
 
 
@@ -90,7 +90,7 @@ Sass Compilation & Live Reloading
 
 If you’d like to take advantage of live reloading and Sass / Compass CSS compilation you can do so with a little bit of preparation_.
 
-.. _`Download the latest MailHog release`: https://github.com/mailhog/MailHog/releases
+
 .. _preparation: https://cookiecutter-django.readthedocs.io/en/latest/live-reloading-and-sass-compilation.html
 
 

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -88,7 +88,7 @@ In production, we have Mailgun_ configured to have your back!
 Sass Compilation & Live Reloading
 ---------------------------------
 
-If you’d like to take advantage of live reloading and Sass / Compass CSS compilation you can do so with a little bit of preparation_.
+If you’d like to take advantage of live reloading and Sass compilation you can do so with a little bit of preparation_.
 
 
 .. _preparation: https://cookiecutter-django.readthedocs.io/en/latest/live-reloading-and-sass-compilation.html

--- a/docs/live-reloading-and-sass-compilation.rst
+++ b/docs/live-reloading-and-sass-compilation.rst
@@ -1,24 +1,22 @@
 Sass Compilation & Live Reloading
 =================================
 
-If you'd like to take advantage of live reloading and Sass / Compass CSS compilation you can do so with a little bit of prep work.
+If you'd like to take advantage of `live reload`_ and Sass compilation:
 
-Make sure that nodejs_ is installed. Then in the project root run::
+- Make sure that nodejs_ is installed. Then in the project root run::
 
     $ npm install
 
 .. _nodejs: http://nodejs.org/download/
 
-If you don't already have it, install `compass` (doesn't hurt if you run this command twice)::
-
-    gem install compass
-
-Now you just need::
+- Now you just need::
 
     $ npm run dev
 
 The base app will now run as it would with the usual ``manage.py runserver`` but with live reloading and Sass compilation enabled.
+When changing your Sass files, they will be automatically recompiled and change will be reflected in your browser without refreshing.
 
 To get live reloading to work you'll probably need to install an `appropriate browser extension`_
 
+.. _live reload: http://livereload.com/
 .. _appropriate browser extension: http://livereload.com/extensions/

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -95,16 +95,25 @@ With MailHog running, to view messages that are sent by your application, open y
 {% else %}
 In development, it is often nice to be able to see emails that are being sent from your application. If you choose to use `MailHog`_ when generating the project a local SMTP server with a web interface will be available.
 
-To start the service, make sure you have nodejs installed, and then type the following::
+#. `Download the latest MailHog release`_ for your OS.
 
-    $ npm install
-    $ grunt serve
+#. Rename the build to ``MailHog``.
 
-(After the first run you only need to type ``grunt serve``) This will start an email server that listens on ``127.0.0.1:1025`` in addition to starting your Django project and a watch task for live reload.
+#. Copy the file to the project root.
 
-To view messages that are sent by your application, open your browser and go to ``http://127.0.0.1:8025``
+#. Make it executable: ::
 
-The email server will exit when you exit the Grunt task on the CLI with Ctrl+C.
+    $ chmod +x MailHog
+
+#. Spin up another terminal window and start it there: ::
+
+    ./MailHog
+
+#. Check out `<http://127.0.0.1:8025/>`_ to see how it goes.
+
+Now you have your own mail server running locally, ready to receive whatever you send it.
+
+.. _`Download the latest MailHog release`: https://github.com/mailhog/MailHog/releases
 {% endif %}
 .. _mailhog: https://github.com/mailhog/MailHog
 {% endif %}


### PR DESCRIPTION
## Description

- Remove outdated references to Grunt in the generated docs.
- Remove references to Compass.



## Rationale

- Grunt support has been dropped in #1636 so there shouldn't be any mention of it.
- Compass is no longer maintained and isn't required anymore as far as I can tell.

Closes #1721.