### PR TITLE
fixed production bugs in caddyfile and middleware

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/caddy/Caddyfile
+++ b/{{cookiecutter.project_slug}}/compose/production/caddy/Caddyfile
@@ -1,5 +1,5 @@
 www.{% raw %}{$DOMAIN_NAME}{% endraw %} {
-    redir https://{{cookiecutter.domain_name}}
+    redir https://{% raw %}{$DOMAIN_NAME}{% endraw %}
 }
 
 {% raw %}{$DOMAIN_NAME}{% endraw %} {

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -164,7 +164,7 @@ INSTALLED_APPS += ['gunicorn']  # noqa F405
 # WhiteNoise
 # ------------------------------------------------------------------------------
 # http://whitenoise.evans.io/en/latest/django.html#enable-whitenoise
-MIDDLEWARE = ['whitenoise.middleware.WhiteNoiseMiddleware'] + MIDDLEWARE  # noqa F405
+MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')  # noqa F405
 
 {% endif %}
 {%- if cookiecutter.use_compressor == 'y' -%}


### PR DESCRIPTION
## Description

Fix bugs in the production environment configuration.

## Rationale

Caddyfile change - the redirect should be consistent with the main site definition, which uses the env variable $DOMAIN_NAME

Settings change - Whitenoise docs say to place middleware *DIRECTLY AFTER* Django security middleware per http://whitenoise.evans.io/en/stable/django.html#enable-whitenoise
