### PR TITLE
Remove requirements.txt file from delete list.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -78,6 +78,7 @@ Listed in alphabetical order.
   Chris Franklin           `@hairychris`_
   Chris Pappalardo         `@ChrisPappalardo`_
   Christopher Clarke       `@chrisdev`_
+  Cole Mackenzie           `@cmackenzie1`_
   Collederas               `@Collederas`_
   Cristian Vargas          `@cdvv7788`_
   Cullen Rhodes            `@c-rhodes`_
@@ -198,6 +199,7 @@ Listed in alphabetical order.
 .. _@chrisdev: https://github.com/chrisdev
 .. _@ChrisPappalardo: https://github.com/ChrisPappalardo
 .. _@chuckus: https://github.com/chuckus
+.. _@cmackenzie1: https://github.com/cmackenzie1
 .. _@Collederas: https://github.com/Collederas
 .. _@ddiazpinto: https://github.com/ddiazpinto
 .. _@dezoito: https://github.com/dezoito

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -69,8 +69,11 @@ def remove_utility_files():
 
 
 def remove_heroku_files():
-    file_names = ["Procfile", "runtime.txt"]
+    file_names = ["Procfile", "runtime.txt", "requirements.txt"]
     for file_name in file_names:
+        if file_name == "requirements.txt" and "{{ cookiecutter.use_travisci }}".lower() == "y":
+            # don't remove the file if we are using travisci but not using heroku
+            continue
         os.remove(file_name)
 
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -69,7 +69,7 @@ def remove_utility_files():
 
 
 def remove_heroku_files():
-    file_names = ["Procfile", "runtime.txt", "requirements.txt"]
+    file_names = ["Procfile", "runtime.txt"]
     for file_name in file_names:
         os.remove(file_name)
 


### PR DESCRIPTION
refs #1829

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Removing the `requirements.txt` from the list of files to delete if heroku is not enabled.



## Rationale

[//]: # (Why does the project need that?)
Using TravisCI but not enabling Heroku causes the `requirements.txt` file in the root dir to be deleted, thus needing an overridden `.travis.yml` install key.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

As a user of this template, I want to create an app without Heroku support, but support for TravisCI, using the output of `cookiecutter`
