### PR TITLE
Add Postgres 10.5 version support

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -106,6 +106,7 @@ Listed in alphabetical order.
   Irfan Ahmad              `@erfaan`_                    @erfaan
   Jan Van Bruggen          `@jvanbrug`_
   Jens Nilsson             `@phiberjenz`_
+  Jerome Leclanche         `@jleclanche`_                @Adys
   Jimmy Gitonga            `@afrowave`_                  @afrowave
   John Cass                `@jcass77`_                   @cass_john
   Julien Almarcha          `@sladinji`_
@@ -216,12 +217,13 @@ Listed in alphabetical order.
 .. _@goldhand: https://github.com/goldhand
 .. _@hackebrot: https://github.com/hackebrot
 .. _@hairychris: https://github.com/hairychris
-.. _@hendrikschneider https://github.com/hendrikschneider
+.. _@hendrikschneider: https://github.com/hendrikschneider
 .. _@hjwp: https://github.com/hjwp
 .. _@IanLee1521: https://github.com/IanLee1521
 .. _@ikkebr: https://github.com/ikkebr
 .. _@iynaix: https://github.com/iynaix
 .. _@jazztpt: https://github.com/jazztpt
+.. _@jleclanche: https://github.com/jleclanche
 .. _@juliocc: https://github.com/juliocc
 .. _@jvanbrug: https://github.com/jvanbrug
 .. _@ka7eh: https://github.com/ka7eh

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,7 @@
   "use_pycharm": "n",
   "use_docker": "n",
   "postgresql_version": [
+    "10.5",
     "10.4",
     "10.3",
     "10.2",


### PR DESCRIPTION
## Description
Allows selecting Postgres version [10.5](https://www.postgresql.org/docs/10/static/release-10-5.html).