### PR TITLE
Modified command for Windows users

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -171,6 +171,7 @@ Listed in alphabetical order.
   William Archinal         `@archinal`_
   Yaroslav Halchenko
   Denis Bobrov             `@delneg`_
+  Philipp Matthies         `@canonnervio`_
 ========================== ============================ ==============
 
 .. _@a7p: https://github.com/a7p

--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -10,6 +10,8 @@ Run these commands to deploy the project to Heroku:
     heroku create --buildpack https://github.com/heroku/heroku-buildpack-python
 
     heroku addons:create heroku-postgresql:hobby-dev
+    # On Windows use double quotes for the time zone, e.g.
+    # heroku pg:backups schedule --at "02:00 America/Los_Angeles" DATABASE_URL
     heroku pg:backups schedule --at '02:00 America/Los_Angeles' DATABASE_URL
     heroku pg:promote DATABASE_URL
 


### PR DESCRIPTION
Added comment to use double quotes for heroku pg:backups setup under Windows.
Current single quotes lead to (not very helpful) error message:
 »   Error: Unexpected argument: DATABASE_URL