### PR TITLE
CSRF in header

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/caddy/Caddyfile
+++ b/{{cookiecutter.project_slug}}/compose/production/caddy/Caddyfile
@@ -7,6 +7,7 @@ www.{% raw %}{$DOMAIN_NAME}{% endraw %} {
         header_upstream Host {host}
         header_upstream X-Real-IP {remote}
         header_upstream X-Forwarded-Proto {scheme}
+        header_upstream X-CSRFToken {~csrftoken}
     }
     log stdout
     errors stdout


### PR DESCRIPTION
CSRF header is needed for a POST request in the Django REST framework.

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)




## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


