### PR TITLE
Added GoAccess analytics for Docker-based deployment

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -91,6 +91,7 @@ Listed in alphabetical order.
   Davit Tovmasyan          `@davitovmasyan`_
   Davur Clementsen         `@dsclementsen`_              @davur
   Delio Castillo           `@jangeador`_                 @jangeador
+  Demetris Stavrou         `@demestav`_
   Denis Orehovsky          `@apirobot`_
   Dónal Adams              `@epileptic-fish`_
   Diane Chen               `@purplediane`_               @purplediane88
@@ -213,6 +214,7 @@ Listed in alphabetical order.
 .. _@Collederas: https://github.com/Collederas
 .. _@davitovmasyan: https://github.com/davitovmasyan
 .. _@ddiazpinto: https://github.com/ddiazpinto
+.. _@demestav: https://github.com/demestav
 .. _@dezoito: https://github.com/dezoito
 .. _@dhepper: https://github.com/dhepper
 .. _@dot2dotseurat: https://github.com/dot2dotseurat

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -41,6 +41,7 @@
   "use_heroku": "n",
   "use_travisci": "n",
   "keep_local_envs_in_vcs": "y",
+  "use_goaccess": "n",
 
   "debug": "n"
 }

--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -118,6 +118,9 @@ To see how your containers are doing run::
 
     docker-compose -f production.yml ps
 
+To view the GoAccess analytics run::
+
+    docker-compose -f production.yml run --rm goaccess goaccess --log-format COMBINED --log-file /srv/logs/requests.log
 
 Example: Supervisor
 -------------------

--- a/{{cookiecutter.project_slug}}/compose/production/caddy/Caddyfile
+++ b/{{cookiecutter.project_slug}}/compose/production/caddy/Caddyfile
@@ -9,7 +9,11 @@ www.{% raw %}{$DOMAIN_NAME}{% endraw %} {
         header_upstream X-Forwarded-Proto {scheme}
         header_upstream X-CSRFToken {~csrftoken}
     }
+    {%- if cookiecutter.use_goaccess == "y" %}
+    log / /var/log/caddy/requests.log "{combined}"
+    {%- else %}
     log stdout
+    {%- endif %}
     errors stdout
     gzip
 }

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -4,6 +4,7 @@ volumes:
   production_postgres_data: {}
   production_postgres_data_backups: {}
   production_caddy: {}
+  production_caddy_log: {}
 
 services:
   django:{% if cookiecutter.use_celery == 'y' %} &django{% endif %}
@@ -39,6 +40,7 @@ services:
       - django
     volumes:
       - production_caddy:/root/.caddy
+      - production_caddy_log:/var/log/caddy
     env_file:
       - ./.envs/.production/.caddy
     ports:
@@ -67,3 +69,11 @@ services:
     command: /start-flower
 
   {%- endif %}
+
+  {% if cookiecutter.use_goaccess == "y" %}
+  goaccess:
+    image: allinurl/goaccess
+    volumes:
+      - production_caddy_log:/srv/logs
+
+  {% endif %}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
This PR adds [GoAccess](https://goaccess.io/) analytics.

## Rationale

[//]: # (Why does the project need that?)
A production level application can benefit from the insights offered by the webserver (Caddy at the moment that this PR was submitted) analytics.

## Notes
GoAccess offers both terminal and browser based visualization, with the latter being prettier of course. This PR enables the terminal based visualization.

To see this in action:
1) Create a new project, and choose `y` for Docker
2) Choose `y` for GoAccess
3) Start the `production.yml` configuration i.e. `docker-compose -f production.yml up`
4) And then `docker-compose -f production.yml run --rm goaccess goaccess --log-format COMBINED --log-file /srv/logs/requests.log`