### PR TITLE
Change eager celery setting in local Docker

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -179,6 +179,7 @@ Listed in alphabetical order.
   Denis Bobrov             `@delneg`_
   Philipp Matthies         `@canonnervio`_
   Vadim Iskuchekov         `@Egregors`_                 @egregors
+  Keith Bailey             `@keithjeb`_
 ========================== ============================ ==============
 
 .. _@a7p: https://github.com/a7p
@@ -295,6 +296,7 @@ Listed in alphabetical order.
 .. _@purplediane: https://github.com/purplediane
 .. _@umrashrf: https://github.com/umrashrf
 .. _@ahhda: https://github.com/ahhda
+.. _@keithjeb: https://github.com/keithjeb
 Special Thanks
 ~~~~~~~~~~~~~~
 

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -171,6 +171,13 @@ When developing locally you can go with MailHog_ for email testing provided ``us
 
 .. _Mailhog: https://github.com/mailhog/MailHog/
 
+.. _`CeleryTasks`:
+
+Celery tasks in local development
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default Celery tasks are set to 'eager' during local development. This results in tasks being evaluated as normal functions which will not reach the redis queue.
+
+If you need tasks to be executed by a worker during development set CELERY_TASK_ALWAYS_EAGER = False in config/settings/local.py
 
 .. _`CeleryFlower`:
 

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -175,9 +175,12 @@ When developing locally you can go with MailHog_ for email testing provided ``us
 
 Celery tasks in local development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-By default Celery tasks are set to 'eager' during local development. This results in tasks being evaluated as normal functions which will not reach the redis queue.
+When not using docker Celery tasks are set to run in Eager mode, so that a full stack is not needed. When using docker the task
+scheduler will be used by default.
 
-If you need tasks to be executed by a worker during development set CELERY_TASK_ALWAYS_EAGER = False in config/settings/local.py
+If you need tasks to be executed on the main thread during development set CELERY_TASK_ALWAYS_EAGER = True in config/settings/local.py.
+
+Possible uses could be for testing, or ease of profiling with DJDT.
 
 .. _`CeleryFlower`:
 

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -118,6 +118,16 @@ In production, we have Mailgun_ configured to have your back!
 .. _Mailgun: https://www.mailgun.com/
 
 
+Celery
+------
+If the project is configured to use Celery as a task scheduler then by default tasks are set to run on the main thread
+when developing locally. If you have the appropriate setup on your local machine then set
+
+CELERY_TASK_ALWAYS_EAGER = False
+
+in /config/settings/local.py
+
+
 Sass Compilation & Live Reloading
 ---------------------------------
 

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -76,7 +76,7 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 
 # Celery
 # ------------------------------------------------------------------------------
-{% if cookiecutter.use_docker == 'n' - %}
+{% if cookiecutter.use_docker == 'n' -%}
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-always-eager
 CELERY_TASK_ALWAYS_EAGER = True
 {%- endif % }

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -79,7 +79,7 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 {% if cookiecutter.use_docker == 'n' -%}
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-always-eager
 CELERY_TASK_ALWAYS_EAGER = True
-{%- endif % }
+{%- endif %}
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-eager-propagates
 CELERY_TASK_EAGER_PROPAGATES = True
 

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -76,8 +76,10 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 
 # Celery
 # ------------------------------------------------------------------------------
+{% if cookiecutter.use_docker == 'n' - %}
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-always-eager
 CELERY_TASK_ALWAYS_EAGER = True
+{%- endif % }
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-eager-propagates
 CELERY_TASK_EAGER_PROPAGATES = True
 


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Added a note around CELERY_TASK_ALWAYS_EAGER = True in docker config for local development. This causes tasks to be executed on the 'main' thread rather than by the workers. I understand why that might be desirable, but thought it worth calling out incase (like me) it makes people think something is broken.


## Rationale

[//]: # (Why does the project need that?)

Ease of use/troubleshooting


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


