### PR TITLE
Update Gulp & other NPM dependencies

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -57,6 +57,7 @@ Listed in alphabetical order.
   Andrew Mikhnevich        `@zcho`_
   Andy Rose
   Anna Callahan            `@jazztpt`_
+  Anna Sidwell             `@takkaria`_
   Antonia Blair            `@antoniablair`_             @antoniablairart
   Anuj Bansal              `@ahhda`_
   Arcuri Davide            `@dadokkio`_
@@ -271,6 +272,7 @@ Listed in alphabetical order.
 .. _@ssteinerX: https://github.com/ssteinerx
 .. _@stepmr: https://github.com/stepmr
 .. _@suledev: https://github.com/suledev
+.. _@takkaria: https://github.com/takkaria
 .. _@timfreund: https://github.com/timfreund
 .. _@Travistock: https://github.com/Tavistock
 .. _@trungdong: https://github.com/trungdong

--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -25,25 +25,25 @@ const uglify = require('gulp-uglify-es').default
 
 // Relative paths function
 function pathsConfig(appName) {
-  this.app = "./" + (appName || pjson.name)
-  var vendorsRoot = 'node_modules/'
+  this.app = `./${pjson.name}`
+  const vendorsRoot = 'node_modules'
 
   return {
     {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
-    bootstrapSass: vendorsRoot + '/bootstrap/scss',
+    bootstrapSass: `${vendorsRoot}/bootstrap/scss`,
     vendorsJs: [
-      vendorsRoot + 'jquery/dist/jquery.slim.js',
-      vendorsRoot + 'popper.js/dist/umd/popper.js',
-      vendorsRoot + 'bootstrap/dist/js/bootstrap.js'
+      `${vendorsRoot}/jquery/dist/jquery.slim.js`,
+      `${vendorsRoot}/popper.js/dist/umd/popper.js`,
+      `${vendorsRoot}/bootstrap/dist/js/bootstrap.js`,
     ],
     {% endif %}
     app: this.app,
-    templates: this.app + '/templates',
-    css: this.app + '/static/css',
-    sass: this.app + '/static/sass',
-    fonts: this.app + '/static/fonts',
-    images: this.app + '/static/images',
-    js: this.app + '/static/js'
+    templates: `${this.app}/templates`,
+    css: `${this.app}/static/css`,
+    sass: `${this.app}/static/sass`,
+    fonts: `${this.app}/static/fonts`,
+    images: `${this.app}/static/images`,
+    js: `${this.app}/static/js`,
   }
 }
 
@@ -64,7 +64,7 @@ function styles() {
       cssnano({ preset: 'default' })   // minify result
   ]
 
-  return src(paths.sass + '/project.scss')
+  return src(`${paths.sass}/project.scss`)
     .pipe(sass({
       includePaths: [
         {% if cookiecutter.custom_bootstrap_compilation == 'y' %}
@@ -83,7 +83,7 @@ function styles() {
 
 // Javascript minification
 function scripts() {
-  return src(paths.js + '/project.js')
+  return src(`${paths.js}/project.js`)
     .pipe(plumber()) // Checks for errors
     .pipe(uglify()) // Minifies the js
     .pipe(rename({ suffix: '.min' }))
@@ -105,18 +105,10 @@ function vendorScripts() {
 
 // Image compression
 function imgCompression() {
-  return src(paths.images + '/*')
+  return src(`${paths.images}/*`)
     .pipe(imagemin()) // Compresses PNG, JPEG, GIF and SVG images
     .pipe(dest(paths.images))
 }
-
-// Generate all assets
-const generateAssets = parallel(
-  styles,
-  scripts,
-  {% if cookiecutter.custom_bootstrap_compilation == 'y' %}vendorScripts,{% endif %}
-  imgCompression
-)
 
 // Run django server
 function runServer(cb) {
@@ -130,18 +122,30 @@ function runServer(cb) {
 // Browser sync server for live reload
 function initBrowserSync() {
     browserSync.init(
-      [paths.css + "/*.css", paths.js + "*.js", paths.templates + '*.html'], {
-        proxy:  "localhost:8000"
-    })
+      [
+        `${paths.css}/*.css`,
+        `${paths.js}/*.js`,
+        `${paths.templates}/*.html`
+      ], {
+        proxy: "localhost:8000"
+      }
+    )
 }
 
 // Watch
 function watchPaths() {
-  watch(paths.sass + '/*.scss', styles)
-  watch(paths.js + '/*.js', scripts).on("change", reload)
-  watch(paths.images + '/*', imgCompression)
-  watch(paths.templates + '/**/*.html').on("change", reload)
+  watch(`${paths.sass}/*.scss`, styles)
+  watch(`${paths.templates}/**/*.html`).on("change", reload)
+  watch([`${paths.js}/*.js`, `!${paths.js}/*.min.js`], scripts).on("change", reload)
 }
+
+// Generate all assets
+const generateAssets = parallel(
+  styles,
+  scripts,
+  {% if cookiecutter.custom_bootstrap_compilation == 'y' %}vendorScripts,{% endif %}
+  imgCompression
+)
 
 // Set up dev environment
 const dev = parallel(
@@ -151,3 +155,5 @@ const dev = parallel(
 )
 
 exports.default = series(generateAssets, dev)
+exports["generate-assets"] = generateAssets
+exports["dev"] = dev

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -6,32 +6,29 @@
     {% if cookiecutter.js_task_runner == 'Gulp' -%}
     {% if cookiecutter.custom_bootstrap_compilation == 'y' -%}
     "bootstrap": "4.1.1",
-    {% endif -%}
-    "browser-sync": "^2.14.0",
-    "del": "^2.2.2",
-    "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^5.0.0",
-    {% if cookiecutter.custom_bootstrap_compilation == 'y' -%}
     "gulp-concat": "^2.6.1",
-    {% endif -%}
-    "gulp-cssnano": "^2.1.2",
-    "gulp-imagemin": "^4.1.0",
-    "gulp-pixrem": "^1.0.0",
-    "gulp-plumber": "^1.1.0",
-    "gulp-rename": "^1.2.2",
-    "gulp-sass": "^3.1.0",
-    "gulp-uglify": "^3.0.0",
-    "gulp-util": "^3.0.7",
-    {% if cookiecutter.custom_bootstrap_compilation == 'y' -%}
     "jquery": "3.3.1",
     "popper.js": "1.14.3",
     {% endif -%}
-    "run-sequence": "^2.1.1"
+    "autoprefixer": "^9.4.7",
+    "browser-sync": "^2.14.0",
+    "cssnano": "^4.1.10",
+    "gulp": "^4.0.0",
+    "gulp-imagemin": "^5.0.3",
+    "gulp-plumber": "^1.2.1",
+    "gulp-postcss": "^8.0.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-sass": "^4.0.2",
+    "gulp-uglify-es": "^1.0.4",
+    "pixrem": "^5.0.0"
     {%- endif %}
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=8"
   },
+  "browserslist": [
+    "last 2 versions"
+  ],
   "scripts": {
     {% if cookiecutter.js_task_runner == 'Gulp' -%}
     "dev": "gulp"


### PR DESCRIPTION
## Description

Upgrade to Gulp 4 and up-to-date versions of the packages the gulpfile uses.  Changes include:
* moving from `gulp-uglify` to `gulp-uglify-es` (which supports modern JS syntax)
* requiring a newer version of Node (current is 0.8) and using newer JS syntax in the gulpfile as a result
* putting the browserslist definition in package.json instead of hidden in the gulpfile

Feedback requested on:
* package.json no longer lists everything in alphabetical order.  Since JSON doesn't allow trailing commas in lists, there would have been some icky templating logic to work out where to put the final comma in the package list.  I can put this in but it seemed cleaner not to.

## Rationale

It's good to keep dependencies up to date!

Fixes #1937.