### PR TITLE
Added tornado <6.0 as an explicit dependency

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -13,6 +13,7 @@ redis>=2.10.6, < 3  # pyup: < 3 # https://github.com/antirez/redis
 celery==4.2.1  # pyup: < 5.0  # https://github.com/celery/celery
 {%- if cookiecutter.use_docker == 'y' %}
 flower==0.9.2  # https://github.com/mher/flower
+tornado>=4.2.0,<6.0.0 #https://github.com/tornadoweb/tornado/tree/stable required as 6.0 breaks flower.
 {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing?)
Add Tornado <6 to dependencies.

## Rationale

[//]: # (Why does the project need that?)
Tornado 6 breaks flower 0.9.2. They have fixed their requirements on github but not released to pypi. This is a bodge round it till they do.



## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
Newly built docker images will pickup tornado 6.0 and therefore flower doesn't run. This might be better as an issue incase upstream is fixed, but they haven't released since 2017 so maybe not quick.

