### PR TITLE
Add missing `script` key to Travis CI config

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -71,6 +71,7 @@ Listed in alphabetical order.
   Bo Lopker                `@blopker`_
   Bouke Haarsma
   Brent Payne              `@brentpayne`_               @brentpayne
+  Bartek                   `@btknu`
   Burhan Khalid            `@burhan`_                   @burhan
   Carl Johnson             `@carlmjohnson`_             @carlmjohnson
   Catherine Devlin         `@catherinedevlin`_
@@ -299,6 +300,7 @@ Listed in alphabetical order.
 .. _@umrashrf: https://github.com/umrashrf
 .. _@ahhda: https://github.com/ahhda
 .. _@keithjeb: https://github.com/keithjeb
+.. _@btknu: https://github.com/btknu
 Special Thanks
 ~~~~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flake8==3.7.6
 tox==3.6.1
 pytest==4.3.0
 pytest-cookies==0.3.0
+pyyaml==3.13

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sh
+import yaml
 
 import pytest
 from binaryornot.check import is_binary
@@ -85,3 +86,19 @@ def test_flake8_compliance(cookies):
         sh.flake8(str(result.project))
     except sh.ErrorReturnCode as e:
         pytest.fail(e)
+
+
+def test_travis_invokes_pytest(cookies, context):
+    context.update({"use_travisci": "y"})
+    result = cookies.bake(extra_context=context)
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project.basename == context["project_slug"]
+    assert result.project.isdir()
+
+    with open(f'{result.project}/.travis.yml', 'r') as travis_yml:
+        try:
+            assert yaml.load(travis_yml)['script'] == ['pytest']
+        except yaml.YAMLError as e:
+            pytest.fail(e)

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -9,3 +9,7 @@ before_install:
 language: python
 python:
   - "3.6"
+install:
+  - pip install -r requirements/local.txt
+script:
+  - "pytest"


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

1. Adds a simple test that verifies presence of `.travis.yml` file and that it contains a `script` key set to `pytest`.

2. Implements the change, i.e. adds pytest to `.travis.yml` based on discussions from: https://github.com/pydanny/cookiecutter-django/issues/1829 and https://github.com/pydanny/cookiecutter-django/issues/550 .

More details in commit messages.


[//]: # (What's it you're proposing?)




## Rationale

Fixes https://github.com/pydanny/cookiecutter-django/issues/1829 .


[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)


Demo repository generated using the updated code can be found here: https://github.com/btknu/cookiecutter-django-demo 

Additionally here is the corresponding Travis CI log, now green: https://travis-ci.org/btknu/cookiecutter-django-demo/builds/502311512 .

[//]: # ("Better to see something once than to hear about it a thousand times.")

