### PR TITLE
Redis and Kombu update

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -145,6 +145,7 @@ Listed in alphabetical order.
   Mesut Yılmaz             `@myilmaz`_
   Michael Gecht            `@mimischi`_                  @_mischi
   mozillazg                `@mozillazg`_
+  Oleg Russkin             `@rolep`_
   Pablo                    `@oubiga`_
   Parbhat Puri             `@parbhat`_
   Peter Bittner            `@bittner`_

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -11,6 +11,7 @@ whitenoise==4.1.2  # https://github.com/evansd/whitenoise
 redis>=3.2.0  # https://github.com/antirez/redis
 {%- if cookiecutter.use_celery == "y" %}
 celery==4.2.1  # pyup: < 5.0  # https://github.com/celery/celery
+kombu==4.4.0  # https://github.com/celery/kombu
 {%- if cookiecutter.use_docker == 'y' %}
 flower==0.9.2  # https://github.com/mher/flower
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -8,7 +8,7 @@ argon2-cffi==19.1.0  # https://github.com/hynek/argon2_cffi
 {%- if cookiecutter.use_whitenoise == 'y' %}
 whitenoise==4.1.2  # https://github.com/evansd/whitenoise
 {%- endif %}
-redis>=2.10.6, < 3  # pyup: < 3 # https://github.com/antirez/redis
+redis>=3.2.0  # https://github.com/antirez/redis
 {%- if cookiecutter.use_celery == "y" %}
 celery==4.2.1  # pyup: < 5.0  # https://github.com/celery/celery
 {%- if cookiecutter.use_docker == 'y' %}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Use recent versions or redis==3.2.0
and kombu==4.4.0

Fixes: pydanny/cookiecutter-django#1954


## Rationale

[//]: # (Why does the project need that?)

Previously redis version was pinned by pydanny/cookiecutter-django#1869
due to bug pydanny/cookiecutter-django#1868

Related bug in kombu celery/kombu#947
was fixed at least in 4.3.0

kombu 4.3.0 although contains another bug celery/kombu#1006
fixed in 4.4.0

kombu 4.4.0 strictly requires redis>=3.2.0

Pinning to older version of kombu / redis does not feel to be in the spirit 
of this project, and older redis version was pinned due to bug in kombu which
was fixed

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

New installs will get recent versions of kombu which require redis 3.2.0
