### PR TITLE
Update django-anymail to 6.0

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -14,4 +14,4 @@ sentry-sdk==0.7.6  # https://github.com/getsentry/sentry-python
 # Django
 # ------------------------------------------------------------------------------
 django-storages[boto3]==1.7.1  # https://github.com/jschneier/django-storages
-django-anymail[mailgun]==5.0  # https://github.com/anymail/django-anymail
+django-anymail[mailgun]==6.0  # https://github.com/anymail/django-anymail


### PR DESCRIPTION

This PR updates [django-anymail[mailgun]](https://pypi.org/project/django-anymail) from **5.0** to **6.0**.





---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
