### PR TITLE
Cloud provider docs update

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -177,6 +177,7 @@ Listed in alphabetical order.
   Travis McNeill           `@Travistock`_               @tavistock_esq
   Tubo Shi                 `@Tubo`_
   Umair Ashraf             `@umrashrf`_                 @fabumair
+  Vlad Doster              `@vladdoster`_
   Vitaly Babiy
   Vivian Guillen           `@viviangb`_
   Will Farley              `@goldhand`_                 @g01dhand
@@ -315,6 +316,7 @@ Listed in alphabetical order.
 .. _@mrcoles: https://github.com/mrcoles
 .. _@ericgroom: https://github.com/ericgroom
 .. _@hanaquadara: https://github.com/hanaquadara
+.. _@vladdoster: https://github.com/vladdoster
 
 Special Thanks
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Features
 * Comes with custom user model ready to go
 * Optional custom static build using Gulp and livereload
 * Send emails via Anymail_ (using Mailgun_ by default, but switchable)
-* Media storage using Amazon S3
+* Media storage using Amazon S3 or Google Cloud Storage
 * Docker support using docker-compose_ for development and production (using Traefik_ with LetsEncrypt_ support)
 * Procfile_ for deploying to Heroku
 * Instructions for deploying to PythonAnywhere_
@@ -62,7 +62,7 @@ Optional Integrations
 
 *These features can be enabled during initial project setup.*
 
-* Serve static files from Amazon S3 or Whitenoise_
+* Serve static files from Amazon S3, Google Cloud Storage or Whitenoise_
 * Configuration for Celery_ and Flower_ (the latter in Docker setup only)
 * Integration with MailHog_ for local email testing
 * Integration with Sentry_ for error logging
@@ -180,6 +180,10 @@ Answer the prompts with your own desired options_. For example::
     Select js_task_runner:
     1 - None
     2 - Gulp
+    Choose from 1, 2 [1]: 1
+    Select cloud_provider:
+    1 - AWS
+    2 - GCS
     Choose from 1, 2 [1]: 1
     custom_bootstrap_compilation [n]: n
     Select open_source_license:

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -64,7 +64,7 @@ js_task_runner:
     2. Gulp_
 
 cloud_provider:
-    Select a cloud provider for static files. The choices are:
+    Select a cloud provider for static & media files. The choices are:
 
     1. AWS_
     2. GCS_

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -63,6 +63,12 @@ js_task_runner:
     1. None
     2. Gulp_
 
+cloud_provider:
+    Select a cloud provider for static files. The choices are:
+
+    1. AWS_
+    2. GCS_
+
 custom_bootstrap_compilation:
     Indicates whether the project should support Bootstrap recompilation
     via the selected JavaScript task runner's task. This can be useful

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -121,6 +121,9 @@ debug:
 
 .. _Gulp: https://github.com/gulpjs/gulp
 
+.. _AWS: https://aws.amazon.com/s3/
+.. _GCS: https://cloud.google.com/storage/
+
 .. _Django Compressor: https://github.com/django-compressor/django-compressor
 
 .. _Celery: https://github.com/celery/celery

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -45,6 +45,7 @@ DJANGO_AWS_ACCESS_KEY_ID                AWS_ACCESS_KEY_ID           n/a         
 DJANGO_AWS_SECRET_ACCESS_KEY            AWS_SECRET_ACCESS_KEY       n/a                                            raises error
 DJANGO_AWS_STORAGE_BUCKET_NAME          AWS_STORAGE_BUCKET_NAME     n/a                                            raises error
 DJANGO_AWS_S3_REGION_NAME               AWS_S3_REGION_NAME          n/a                                            None
+DJANGO_GCE_STORAGE_BUCKET_NAME          GS_BUCKET_NAME              n/a                                            raises error
 SENTRY_DSN                              SENTRY_DSN                  n/a                                            raises error
 DJANGO_SENTRY_LOG_LEVEL                 SENTRY_LOG_LEVEL            n/a                                            logging.INFO
 MAILGUN_API_KEY                         MAILGUN_ACCESS_KEY          n/a                                            raises error

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,6 +46,7 @@ DJANGO_AWS_SECRET_ACCESS_KEY            AWS_SECRET_ACCESS_KEY       n/a         
 DJANGO_AWS_STORAGE_BUCKET_NAME          AWS_STORAGE_BUCKET_NAME     n/a                                            raises error
 DJANGO_AWS_S3_REGION_NAME               AWS_S3_REGION_NAME          n/a                                            None
 DJANGO_GCE_STORAGE_BUCKET_NAME          GS_BUCKET_NAME              n/a                                            raises error
+GOOGLE_APPLICATION_CREDENTIALS          n/a                         n/a                                            raises error
 SENTRY_DSN                              SENTRY_DSN                  n/a                                            raises error
 DJANGO_SENTRY_LOG_LEVEL                 SENTRY_LOG_LEVEL            n/a                                            logging.INFO
 MAILGUN_API_KEY                         MAILGUN_ACCESS_KEY          n/a                                            raises error


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description
Updated documentation to reflect the addition of Google Cloud Storage as an option to serve static files from.

[//]: # (What's it you're proposing?)

## Rationale

[//]: # (Why does the project need that?)
So new users are aware of different development setups available from Django Cookie cutter.


## Use case(s) / visualization(s)
A user wants to create a new project from Django Cookiecutter. They will now see that they can choose between AWS and GCS as a provider for serving static files.

[//]: # ("Better to see something once than to hear about it a thousand times.")

Fixes #2026 
