### PR TITLE
 Edit STATIC and MEDIA urls for GCE production.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -84,6 +84,7 @@ Listed in alphabetical order.
   Christopher Clarke       `@chrisdev`_
   Cole Mackenzie           `@cmackenzie1`_
   Collederas               `@Collederas`_
+  Craig Margieson          `@cmargieson`_
   Cristian Vargas          `@cdvv7788`_
   Cullen Rhodes            `@c-rhodes`_
   Dan Shultz               `@shultz`_

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -318,6 +318,7 @@ Listed in alphabetical order.
 .. _@ericgroom: https://github.com/ericgroom
 .. _@hanaquadara: https://github.com/hanaquadara
 .. _@vladdoster: https://github.com/vladdoster
+.. _@cmargieson: https://github.com/cmargieson
 
 Special Thanks
 ~~~~~~~~~~~~~~

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -104,7 +104,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
 STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
 {%- elif cookiecutter.cloud_provider == 'GCE' %}
-STATIC_URL = "https://storage.googleapis.com/{}/static".format(GS_BUCKET_NAME)
+STATIC_URL = "https://storage.googleapis.com/{}/static/".format(GS_BUCKET_NAME)
 {%- endif %}
 
 # MEDIA
@@ -128,8 +128,8 @@ class MediaRootS3Boto3Storage(S3Boto3Storage):
 DEFAULT_FILE_STORAGE = "config.settings.production.MediaRootS3Boto3Storage"
 MEDIA_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/media/"
 {%- elif cookiecutter.cloud_provider == 'GCE' %}
-MEDIA_URL = "https://storage.googleapis.com/{}/media".format(GS_BUCKET_NAME)
-MEDIA_ROOT = "https://storage.googleapis.com/{}/media".format(GS_BUCKET_NAME)
+MEDIA_URL = "https://storage.googleapis.com/{}/media/".format(GS_BUCKET_NAME)
+MEDIA_ROOT = "https://storage.googleapis.com/{}/media/".format(GS_BUCKET_NAME)
 {%- endif %}
 
 # TEMPLATES


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)


Edit STATIC and MEDIA urls in production settings to include a trailing / when Google Cloud Platform is used as a storage service.


## Rationale

[//]: # (Why does the project need that?)

An error occurs on deployment if the / is not included in the environment variable. (Tested on Heroku)


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

tox gives cake, unsurprisingly.
