### PR TITLE
The signal should be imported from project_slug

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/apps.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/apps.py
@@ -8,6 +8,6 @@ class UsersAppConfig(AppConfig):
 
     def ready(self):
         try:
-            import users.signals  # noqa F401
+            import {{ cookiecutter.project_slug }}.users.signals  # noqa F401
         except ImportError:
             pass


### PR DESCRIPTION
I am getting an error if I create a signal.py file under users model. Here is the stacktrace
```
Tracking file by folder pattern:  migrations
Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x000002663A074048>
Traceback (most recent call last):
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\utils\autoreload.py", line 225, in wrapper
    fn(*args, **kwargs)
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\core\management\commands\runserver.py", line 109, in inner_run
    autoreload.raise_last_exception()
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\utils\autoreload.py", line 248, in raise_last_exception
    raise _exception[1]
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\core\management\__init__.py", line 337, in execute
    autoreload.check_errors(django.setup)()
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\utils\autoreload.py", line 225, in wrapper
    fn(*args, **kwargs)
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\apps\registry.py", line 120, in populate
    app_config.ready()
  File "C:\Users\srao\projects\kbs\kbs\users\apps.py", line 11, in ready
    import users.signals  # noqa F401
  File "C:\Users\srao\projects\kbs\kbs\users\signals.py", line 3, in <module>
    from .models import User
  File "C:\Users\srao\projects\kbs\kbs\users\models.py", line 8, in <module>
    class User(AbstractUser):
  File "C:\Apps\Anaconda3\envs\registration\lib\site-packages\django\db\models\base.py", line 95, in __new__
    "INSTALLED_APPS." % (module, name)
RuntimeError: Model class users.models.User doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

Having the signal be imported from project_slug.users.signal fixes the issue.

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
I am proposing the instead of 
    import users.signals  # noqa F401
I am proposing
    import project_slug.users.signals  # noqa F401



## Rationale

[//]: # (Why does the project need that?)
This fixes the runtime error "RuntimeError: Model class users.models.User doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS."




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


