### PR TITLE
Add missing link in CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -320,6 +320,7 @@ Listed in alphabetical order.
 .. _@hanaquadara: https://github.com/hanaquadara
 .. _@vladdoster: https://github.com/vladdoster
 .. _@cmargieson: https://github.com/cmargieson
+.. _@tanoabeleyra: https://github.com/tanoabeleyra
 
 Special Thanks
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
I'm really sorry for opening a PR just for this but I realized that I missed my GitHub link, I thought that it was handled automatically.