### PR TITLE
Add LocaleMiddleware

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -35,6 +35,8 @@ USE_I18N = True
 USE_L10N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
 USE_TZ = True
+# https://docs.djangoproject.com/en/dev/ref/settings/#locale-paths
+LOCALE_PATHS = [ROOT_DIR.path("locale")]
 
 # DATABASES
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -126,6 +126,7 @@ AUTH_PASSWORD_VALIDATORS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
As said couple years ago in #792:

> The settings comes with `USE_I18N` and `USE_L10N` set as `True`, but we need to add `django.middleware.locale.LocaleMiddleware` to make the localization and internationalization work.

The middleware was added here (https://github.com/pydanny/cookiecutter-django/commit/464fb56263a4c5de39d6d333250f797c96a1265a) but it seems that it wasn't merged (https://github.com/pydanny/cookiecutter-django/pull/793).

Is any reason for not adding the middleware by default?