### PR TITLE
Remove user list view

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
@@ -13,11 +13,6 @@ def test_detail(user: settings.AUTH_USER_MODEL):
     assert resolve(f"/users/{user.username}/").view_name == "users:detail"
 
 
-def test_list():
-    assert reverse("users:list") == "/users/"
-    assert resolve("/users/").view_name == "users:list"
-
-
 def test_update():
     assert reverse("users:update") == "/users/~update/"
     assert resolve("/users/~update/").view_name == "users:update"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/urls.py
@@ -1,7 +1,6 @@
 from django.urls import path
 
 from {{ cookiecutter.project_slug }}.users.views import (
-    user_list_view,
     user_redirect_view,
     user_update_view,
     user_detail_view,
@@ -9,7 +8,6 @@ from {{ cookiecutter.project_slug }}.users.views import (
 
 app_name = "users"
 urlpatterns = [
-    path("", view=user_list_view, name="list"),
     path("~redirect/", view=user_redirect_view, name="redirect"),
     path("~update/", view=user_update_view, name="update"),
     path("<str:username>/", view=user_detail_view, name="detail"),

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
-from django.views.generic import DetailView, ListView, RedirectView, UpdateView
+from django.views.generic import DetailView, RedirectView, UpdateView
 
 User = get_user_model()
 
@@ -14,16 +14,6 @@ class UserDetailView(LoginRequiredMixin, DetailView):
 
 
 user_detail_view = UserDetailView.as_view()
-
-
-class UserListView(LoginRequiredMixin, ListView):
-
-    model = User
-    slug_field = "username"
-    slug_url_kwarg = "username"
-
-
-user_list_view = UserListView.as_view()
 
 
 class UserUpdateView(LoginRequiredMixin, UpdateView):


### PR DESCRIPTION
## Description

Fixes #1739. A first attempt was made in #1761, with a different approach, but after seeing the whole implementation, I now believe this view should be deleted. If an admin needs to see all the users, there is the admin for that, after all.

## Rationale

See #1739 for discussion. The purpose of this view is questionable and it's potentially unsecure to expose such a list.