### PR TITLE
Update Redis version to 5.0

### DIFF
--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -45,7 +45,7 @@ services:
   {%- if cookiecutter.use_celery == 'y' %}
 
   redis:
-    image: redis:3.2
+    image: redis:5.0
 
   celeryworker:
     <<: *django

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -44,7 +44,7 @@ services:
       - "0.0.0.0:443:443"
 
   redis:
-    image: redis:3.2
+    image: redis:5.0
   {%- if cookiecutter.use_celery == 'y' %}
 
   celeryworker:


### PR DESCRIPTION
## Description

The latest Redis release is v5.0 and [was released in October](https://redislabs.com/blog/redis-5-0-is-here/). We haven't updated in a while it seems as we are on 3.2. When using Heroku, the add-on is on Redis v4.0, it seems.