### PR TITLE
traefik toml config - storageFile is deprecated, use storage instead

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -143,6 +143,7 @@ Listed in alphabetical order.
   Mateusz Ostaszewski      `@mostaszewski`_
   Mathijs Hoogland         `@MathijsHoogland`_
   Matt Braymer-Hayes       `@mattayes`_                  @mattayes
+  Matt Knapper             `@mknapper1`_
   Matt Linares
   Matt Menzenski           `@menzenski`_
   Matt Warren              `@mfwarren`_
@@ -260,6 +261,7 @@ Listed in alphabetical order.
 .. _@msaizar: https://github.com/msaizar
 .. _@MathijsHoogland: https://github.com/MathijsHoogland
 .. _@mattayes: https://github.com/mattayes
+.. _@mknapper1: https://github.com/mknapper1
 .. _@menzenski: https://github.com/menzenski
 .. _@mostaszewski: https://github.com/mostaszewski
 .. _@mfwarren: https://github.com/mfwarren

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.toml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.toml
@@ -17,7 +17,7 @@ defaultEntryPoints = ["http", "https"]
 [acme]
 # Email address used for registration
 email = "{{ cookiecutter.email }}"
-storageFile = "/etc/traefik/acme/acme.json"
+storage = "/etc/traefik/acme/acme.json"
 entryPoint = "https"
 onDemand = false
 OnHostRule = true


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

The `storageFile` configuration variable for ACME has been deprecated, and replaced with `storage`


## Rationale

[//]: # (Why does the project need that?)
This pull request implements the updated configuration variable name and stops the warning from displaying when starting a cookiecutter-django project that uses Docker.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


