### PR TITLE
Make cloud_provider optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,8 @@ Answer the prompts with your own desired options_. For example::
     Select cloud_provider:
     1 - AWS
     2 - GCS
-    Choose from 1, 2 [1]: 1
+    3 - None
+    Choose from 1, 2, 3 [1]: 1
     custom_bootstrap_compilation [n]: n
     Select open_source_license:
     1 - MIT

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -33,7 +33,8 @@
   ],
   "cloud_provider": [
     "AWS",
-    "GCE"
+    "GCE",
+    "None"
   ],
   "custom_bootstrap_compilation": "n",
   "use_compressor": "n",

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -69,6 +69,7 @@ cloud_provider:
 
     1. AWS_
     2. GCS_
+    3. None
 
 custom_bootstrap_compilation:
     Indicates whether the project should support Bootstrap recompilation

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -328,6 +328,12 @@ def main():
         if "{{ cookiecutter.use_docker }}".lower() == "y":
             remove_node_dockerfile()
 
+    if "{{ cookiecutter.cloud_provider}}".lower() == "none":
+        print(
+            WARNING + "You chose not to use a cloud provider, "
+            "media files won't be served in production." + TERMINATOR
+        )
+
     if "{{ cookiecutter.use_celery }}".lower() == "n":
         remove_celery_files()
         if "{{ cookiecutter.use_docker }}".lower() == "y":

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -11,7 +11,7 @@ PATTERN = "{{(\s?cookiecutter)[.](.*?)}}"
 RE_OBJ = re.compile(PATTERN)
 
 YN_CHOICES = ["y", "n"]
-CLOUD_CHOICES = ["AWS", "GCE"]
+CLOUD_CHOICES = ["AWS", "GCE", "None"]
 
 
 @pytest.fixture

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -68,8 +68,10 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
 
 # STORAGES
 # ------------------------------------------------------------------------------
+{% if cookiecutter.cloud_provider != 'None' -%}
 # https://django-storages.readthedocs.io/en/latest/#installation
 INSTALLED_APPS += ["storages"]  # noqa F405
+{%- endif -%}
 {% if cookiecutter.cloud_provider == 'AWS' %}
 # https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
 AWS_ACCESS_KEY_ID = env("DJANGO_AWS_ACCESS_KEY_ID")
@@ -193,7 +195,7 @@ COMPRESS_ENABLED = env.bool("COMPRESS_ENABLED", default=True)
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_STORAGE
 COMPRESS_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_URL
-COMPRESS_URL = STATIC_URL{% if cookiecutter.use_whitenoise == 'y' %}  # noqa F405{% endif %}
+COMPRESS_URL = STATIC_URL{% if cookiecutter.use_whitenoise == 'y' or cookiecutter.cloud_provider == 'None' %}  # noqa F405{% endif %}
 {% endif %}
 {%- if cookiecutter.use_whitenoise == 'n' -%}
 # Collectfast


### PR DESCRIPTION
Some projects may not need AWS or GCS.

Also use `GCS` as [Google Cloud Storage](https://cloud.google.com/storage/) acronym everywhere (don't alternate between GCE and GCS).