### PR TITLE
If using whitenoise disable AWS and GCE for static

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -99,11 +99,10 @@ GS_DEFAULT_ACL = "publicRead"
 # ------------------------
 {% if cookiecutter.use_whitenoise == 'y' -%}
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-{%- endif -%}
-{%- if cookiecutter.cloud_provider == 'AWS' %}
+{%- elif cookiecutter.cloud_provider == 'AWS' and cookiecutter.use_whitenoise == 'n' %}
 STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
 STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
-{%- elif cookiecutter.cloud_provider == 'GCE' %}
+{%- elif cookiecutter.cloud_provider == 'GCE' and cookiecutter.use_whitenoise == 'n' %}
 STATIC_URL = "https://storage.googleapis.com/{}/static/".format(GS_BUCKET_NAME)
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -99,7 +99,7 @@ GS_DEFAULT_ACL = "publicRead"
 # ------------------------
 {% if cookiecutter.use_whitenoise == 'y' -%}
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-{%- elif cookiecutter.cloud_provider == 'AWS' and cookiecutter.use_whitenoise == 'n' %}
+{%- elif cookiecutter.cloud_provider == 'AWS' %}
 STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
 STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
 {%- elif cookiecutter.cloud_provider == 'GCE' and cookiecutter.use_whitenoise == 'n' %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -102,7 +102,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 {%- elif cookiecutter.cloud_provider == 'AWS' %}
 STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
 STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
-{%- elif cookiecutter.cloud_provider == 'GCE' and cookiecutter.use_whitenoise == 'n' %}
+{%- elif cookiecutter.cloud_provider == 'GCE' %}
 STATIC_URL = "https://storage.googleapis.com/{}/static/".format(GS_BUCKET_NAME)
 {%- endif %}
 


### PR DESCRIPTION
If using whitenoise disable AWS and GCE for static setting.

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
If you choose whitenoise and AWS as your cloud provider, the STATIC settings which gets generated is:
STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
or if whitenoise and GCE is chosen:
STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
STATIC_URL = "https://storage.googleapis.com/{}/static/".format(GS_BUCKET_NAME)

I am proposing that an extra check be placed in production.py where if whitenoise is chosen, AWS and GCE settings are not applied
`
{% if cookiecutter.use_whitenoise == 'y' -%}
STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
{%- elif cookiecutter.cloud_provider == 'AWS' and cookiecutter.use_whitenoise == 'n' %}
STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
{%- elif cookiecutter.cloud_provider == 'GCE' and cookiecutter.use_whitenoise == 'n' %}
STATIC_URL = "https://storage.googleapis.com/{}/static/".format(GS_BUCKET_NAME)
{%- endif %}
`

## Rationale

[//]: # (Why does the project need that?)
This will generate better code



## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


