### PR TITLE
Log errors are sent to Sentry

### DIFF
--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -35,7 +35,15 @@ Configuring the Stack
 
 The majority of services above are configured through the use of environment variables. Just check out :ref:`envs` and you will know the drill.
 
-To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable.
+To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable. Logs of level `logging.ERROR` are sent as Sentry events. Therefore, in order to send a Sentry even use:
+
+.. code-block:: python
+
+    import logging
+    logging.error("This event is sent to Sentry", extra={"<example_key>": "<example_value>"})
+
+The `extra` parameter allows you to send additional information about the context of this error.
+
 
 You will probably also need to setup the Mail backend, for example by adding a `Mailgun`_ API key and a `Mailgun`_ sender domain, otherwise, the account creation view will crash and result in a 500 error when the backend attempts to send an email to the account owner.
 

--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -35,7 +35,7 @@ Configuring the Stack
 
 The majority of services above are configured through the use of environment variables. Just check out :ref:`envs` and you will know the drill.
 
-To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable. Logs of level `logging.ERROR` are sent as Sentry events. Therefore, in order to send a Sentry even use:
+To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable. Logs of level `logging.ERROR` are sent as Sentry events. Therefore, in order to send a Sentry event use:
 
 .. code-block:: python
 

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -288,7 +288,7 @@ SENTRY_LOG_LEVEL = env.int("DJANGO_SENTRY_LOG_LEVEL", logging.INFO)
 
 sentry_logging = LoggingIntegration(
     level=SENTRY_LOG_LEVEL,  # Capture info and above as breadcrumbs
-    event_level=None,  # Send no events from log messages
+    event_level=logging.ERROR  # Send errors as events
 )
 
 {%- if cookiecutter.use_celery == 'y' %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -288,7 +288,7 @@ SENTRY_LOG_LEVEL = env.int("DJANGO_SENTRY_LOG_LEVEL", logging.INFO)
 
 sentry_logging = LoggingIntegration(
     level=SENTRY_LOG_LEVEL,  # Capture info and above as breadcrumbs
-    event_level=logging.ERROR  # Send errors as events
+    event_level=logging.ERROR,  # Send errors as events
 )
 
 {%- if cookiecutter.use_celery == 'y' %}


### PR DESCRIPTION
## Description
Fixes #2073 

## Rationale
It is efficient to utilize an already existing reporting channel (Sentry) for logging errors.


