### PR TITLE
Revert Werkzeug back to 0.14

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,6 +1,6 @@
 -r ./base.txt
 
-Werkzeug==0.15.4  # https://github.com/pallets/werkzeug
+Werkzeug==0.14  # https://github.com/pallets/werkzeug
 ipdb==0.12  # https://github.com/gotcha/ipdb
 Sphinx==2.0.1  # https://github.com/sphinx-doc/sphinx
 {%- if cookiecutter.use_docker == 'y' %}


### PR DESCRIPTION
reverting back Werkzeug to version 0.14 based on discussion on #2070
I did the change locally on my windows laptop and can confirm that this is now working.

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)




## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


