### PR TITLE
Update the Travis config to support the newer version of SQLite for Django 2.2

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -190,6 +190,7 @@ Listed in alphabetical order.
   Vlad Doster              `@vladdoster`_
   Will Farley              `@goldhand`_                 @g01dhand
   William Archinal         `@archinal`_
+  Xaver Y.R. Chen          `@yrchen`_                   @yrchen
   Yaroslav Halchenko
   Keyvan Mosharraf         `@keyvanm`_
 ========================== ============================ ==============
@@ -327,6 +328,7 @@ Listed in alphabetical order.
 .. _@cmargieson: https://github.com/cmargieson
 .. _@tanoabeleyra: https://github.com/tanoabeleyra
 .. _@keyvanm: https://github.com/keyvanm
+.. _@yrchen: https://github.com/yrchen
 
 Special Thanks
 ~~~~~~~~~~~~~~

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -1,8 +1,9 @@
+dist: xenial
 sudo: true
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq build-essential gettext python-dev zlib1g-dev libpq-dev xvfb
-  - sudo apt-get install -qq libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms1-dev libwebp-dev
+  - sudo apt-get install -qq libjpeg8-dev libfreetype6-dev libwebp-dev
   - sudo apt-get install -qq graphviz-dev python-setuptools python3-dev python-virtualenv python-pip
   - sudo apt-get install -qq firefox automake libtool libreadline6 libreadline6-dev libreadline-dev
   - sudo apt-get install -qq libsqlite3-dev libxml2 libxml2-dev libssl-dev libbz2-dev wget curl llvm

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: true
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq build-essential gettext python-dev zlib1g-dev libpq-dev xvfb


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

After upgrade to Django 2.2. The minimal supported version SQLite is increased from 3.7.15 to 3.8.3. The latest version of SQLite on the [default distribution of Travis CI](https://docs.travis-ci.com/user/reference/overview/#linux) is 3.8.2.


## Rationale

[//]: # (Why does the project need that?)

We need to upgrade the Travis CI distribution from 14.04 to 16.04 (xenial).


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

<img width="1073" alt="螢幕截圖 2019-06-06 11 47 46" src="https://user-images.githubusercontent.com/11457/59005630-f161f200-8850-11e9-9acb-1b7d0c7ffd0d.png">
