### PR TITLE
Fix removal carriage returns in docker scripts

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -180,6 +180,7 @@ Listed in alphabetical order.
   Tano Abeleyra            `@tanoabeleyra`_
   Taylor Baldwin
   Théo Segonds             `@show0k`_
+  Tim Claessens            `@timclaessens`
   Tim Freund               `@timfreund`_
   Tom Atkins               `@knitatoms`_
   Tom Offermann
@@ -292,6 +293,7 @@ Listed in alphabetical order.
 .. _@stepmr: https://github.com/stepmr
 .. _@suledev: https://github.com/suledev
 .. _@takkaria: https://github.com/takkaria
+.. _@timclaessens: https://github.com/timclaessens
 .. _@timfreund: https://github.com/timfreund
 .. _@Travistock: https://github.com/Tavistock
 .. _@trungdong: https://github.com/trungdong

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -20,23 +20,23 @@ COPY ./requirements /requirements
 RUN pip install -r /requirements/local.txt
 
 COPY ./compose/production/django/entrypoint /entrypoint
-RUN sed -i 's/\r//' /entrypoint
+RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
 
 COPY ./compose/local/django/start /start
-RUN sed -i 's/\r//' /start
+RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 {% if cookiecutter.use_celery == "y" %}
 COPY ./compose/local/django/celery/worker/start /start-celeryworker
-RUN sed -i 's/\r//' /start-celeryworker
+RUN sed -i 's/\r$//g' /start-celeryworker
 RUN chmod +x /start-celeryworker
 
 COPY ./compose/local/django/celery/beat/start /start-celerybeat
-RUN sed -i 's/\r//' /start-celerybeat
+RUN sed -i 's/\r$//g' /start-celerybeat
 RUN chmod +x /start-celerybeat
 
 COPY ./compose/local/django/celery/flower/start /start-flower
-RUN sed -i 's/\r//' /start-flower
+RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 {% endif %}
 WORKDIR /app

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -31,28 +31,28 @@ RUN pip install --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements
 
 COPY ./compose/production/django/entrypoint /entrypoint
-RUN sed -i 's/\r//' /entrypoint
+RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
 RUN chown django /entrypoint
 
 COPY ./compose/production/django/start /start
-RUN sed -i 's/\r//' /start
+RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 RUN chown django /start
 
 {%- if cookiecutter.use_celery == "y" %}
 COPY ./compose/production/django/celery/worker/start /start-celeryworker
-RUN sed -i 's/\r//' /start-celeryworker
+RUN sed -i 's/\r$//g' /start-celeryworker
 RUN chmod +x /start-celeryworker
 RUN chown django /start-celeryworker
 
 COPY ./compose/production/django/celery/beat/start /start-celerybeat
-RUN sed -i 's/\r//' /start-celerybeat
+RUN sed -i 's/\r$//g' /start-celerybeat
 RUN chmod +x /start-celerybeat
 RUN chown django /start-celerybeat
 
 COPY ./compose/production/django/celery/flower/start /start-flower
-RUN sed -i 's/\r//' /start-flower
+RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 {%- endif %}
 


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description
The dockerfile copies script and removes the carriage returns (<kbd>CR</kbd>). Currently, only the first occurrence of a carriage return in a file is removed. The proposed changes remove _all_ occurrences within a file.

## Rationale
When editing the scripts on a Windows platform, carriage returns can be introduced. This can lead to errors when the (unix-based) docker container tries to execute these scripts. By correctly removing all <kbd>CR</kbd>s, a file is effectively converted from Windows-style to Unix-style.

Also see https://stackoverflow.com/a/41461947.
