### PR TITLE
Always use test settings in pytest

### DIFF
--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings.test
+addopts = --ds=config.settings.test
 {%- if cookiecutter.js_task_runner != 'None' %}
 norecursedirs = node_modules
 {%- endif %}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

You can alternatively use DJANGO_SETTINGS_MODULE, but this is overridden
by the environment variable of the same name. In order to always run it
with test settings, regardless of the environment variable, use --ds.

https://pytest-django.readthedocs.io/en/latest/configuring_django.html

## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


