### PR TITLE
Handle path with pathlib

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -122,6 +122,7 @@ Listed in alphabetical order.
   Jerome Leclanche         `@jleclanche`_                @Adys
   Jimmy Gitonga            `@afrowave`_                  @afrowave
   John Cass                `@jcass77`_                   @cass_john
+  Jules Cheron             `@jules-ch`_
   Julien Almarcha          `@sladinji`_
   Julio Castillo           `@juliocc`_
   Kaido Kert               `@kaidokert`_
@@ -274,6 +275,7 @@ Listed in alphabetical order.
 .. _@jazztpt: https://github.com/jazztpt
 .. _@jcass77: https://github.com/jcass77
 .. _@jleclanche: https://github.com/jleclanche
+.. _@jules-ch: https://github.com/jules-ch
 .. _@juliocc: https://github.com/juliocc
 .. _@jvanbrug: https://github.com/jvanbrug
 .. _@ka7eh: https://github.com/ka7eh

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -4,17 +4,17 @@ Base settings to build other settings files upon.
 
 import environ
 
-ROOT_DIR = (
-    environ.Path(__file__) - 3
-)  # ({{ cookiecutter.project_slug }}/config/settings/base.py - 3 = {{ cookiecutter.project_slug }}/)
-APPS_DIR = ROOT_DIR.path("{{ cookiecutter.project_slug }}")
+from pathlib import Path
 
+ROOT_DIR = Path(__file__).parents[2]
+# {{ cookiecutter.project_slug }}/)
+APPS_DIR = ROOT_DIR / "{{ cookiecutter.project_slug }}"
 env = environ.Env()
 
 READ_DOT_ENV_FILE = env.bool("DJANGO_READ_DOT_ENV_FILE", default=False)
 if READ_DOT_ENV_FILE:
     # OS environment variables take precedence over variables from .env
-    env.read_env(str(ROOT_DIR.path(".env")))
+    env.read_env(str(ROOT_DIR / ".env"))
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ USE_L10N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
 USE_TZ = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#locale-paths
-LOCALE_PATHS = [ROOT_DIR.path("locale")]
+LOCALE_PATHS = [str(ROOT_DIR / "locale")]
 
 # DATABASES
 # ------------------------------------------------------------------------------
@@ -143,11 +143,11 @@ MIDDLEWARE = [
 # STATIC
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
-STATIC_ROOT = str(ROOT_DIR("staticfiles"))
+STATIC_ROOT = str(ROOT_DIR / "staticfiles")
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
-STATICFILES_DIRS = [str(APPS_DIR.path("static"))]
+STATICFILES_DIRS = [str(APPS_DIR / "static")]
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
@@ -157,7 +157,7 @@ STATICFILES_FINDERS = [
 # MEDIA
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
-MEDIA_ROOT = str(APPS_DIR("media"))
+MEDIA_ROOT = str(APPS_DIR / "media")
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = "/media/"
 
@@ -169,7 +169,7 @@ TEMPLATES = [
         # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TEMPLATES-BACKEND
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         # https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
-        "DIRS": [str(APPS_DIR.path("templates"))],
+        "DIRS": [str(APPS_DIR / "templates")],
         "OPTIONS": {
             # https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
             # https://docs.djangoproject.com/en/dev/ref/templates/api/#loader-types
@@ -197,7 +197,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 # FIXTURES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#fixture-dirs
-FIXTURE_DIRS = (str(APPS_DIR.path("fixtures")),)
+FIXTURE_DIRS = (str(APPS_DIR / "fixtures"),)
 
 # SECURITY
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/wsgi.py
+++ b/{{cookiecutter.project_slug}}/config/wsgi.py
@@ -17,13 +17,12 @@ import os
 import sys
 
 from django.core.wsgi import get_wsgi_application
+from pathlib import Path
 
 # This allows easy placement of apps within the interior
 # {{ cookiecutter.project_slug }} directory.
-app_path = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
-)
-sys.path.append(os.path.join(app_path, "{{ cookiecutter.project_slug }}"))
+app_path = Path(__file__).parents[1].resolve()
+sys.path.append(str(app_path / "{{ cookiecutter.project_slug }}"))
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use
 # mod_wsgi daemon mode with each site in its own daemon process, or use

--- a/{{cookiecutter.project_slug}}/manage.py
+++ b/{{cookiecutter.project_slug}}/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+from pathlib import Path
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
@@ -24,7 +25,7 @@ if __name__ == "__main__":
 
     # This allows easy placement of apps within the interior
     # {{ cookiecutter.project_slug }} directory.
-    current_path = os.path.dirname(os.path.abspath(__file__))
-    sys.path.append(os.path.join(current_path, "{{ cookiecutter.project_slug }}"))
+    current_path = Path(__file__).parent.resolve()
+    sys.path.append(str(current_path / "{{ cookiecutter.project_slug }}"))
 
     execute_from_command_line(sys.argv)

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -1,15 +1,16 @@
 import os
 from typing import Sequence
+from pathlib import Path
 
 import pytest
 
-ROOT_DIR_PATH = os.path.dirname(os.path.realpath(__file__))
-PRODUCTION_DOTENVS_DIR_PATH = os.path.join(ROOT_DIR_PATH, ".envs", ".production")
+ROOT_DIR_PATH = Path(__file__).parent.resolve()
+PRODUCTION_DOTENVS_DIR_PATH = ROOT_DIR_PATH.joinpath(".envs", ".production")
 PRODUCTION_DOTENV_FILE_PATHS = [
-    os.path.join(PRODUCTION_DOTENVS_DIR_PATH, ".django"),
-    os.path.join(PRODUCTION_DOTENVS_DIR_PATH, ".postgres"),
+    PRODUCTION_DOTENVS_DIR_PATH / ".django",
+    PRODUCTION_DOTENVS_DIR_PATH / ".postgres",
 ]
-DOTENV_FILE_PATH = os.path.join(ROOT_DIR_PATH, ".env")
+DOTENV_FILE_PATH = ROOT_DIR_PATH / ".env"
 
 
 def merge(
@@ -31,9 +32,9 @@ def main():
 @pytest.mark.parametrize("merged_file_count", range(3))
 @pytest.mark.parametrize("append_linesep", [True, False])
 def test_merge(tmpdir_factory, merged_file_count: int, append_linesep: bool):
-    tmp_dir_path = str(tmpdir_factory.getbasetemp())
+    tmp_dir_path = Path(str(tmpdir_factory.getbasetemp()))
 
-    output_file_path = os.path.join(tmp_dir_path, ".env")
+    output_file_path = tmp_dir_path / ".env"
 
     expected_output_file_content = ""
     merged_file_paths = []
@@ -41,7 +42,7 @@ def test_merge(tmpdir_factory, merged_file_count: int, append_linesep: bool):
         merged_file_ord = i + 1
 
         merged_filename = ".service{}".format(merged_file_ord)
-        merged_file_path = os.path.join(tmp_dir_path, merged_filename)
+        merged_file_path = tmp_dir_path / merged_filename
 
         merged_file_content = merged_filename * merged_file_ord
 


### PR DESCRIPTION
## Description

Fixes #1559 , I changed path handling on settings and some other python files.

The issue mentionned `pre_gen_project` & `post_gen_project` aswell. The header of those files states that it must work with python2.7 for generation even though the project generated is for python >= 3.6. I don't know your position on that so I kept those files as is.

- Update config/settings/base.py
- Update merge_production_dotenvs_in_dotenv.py
- Update wsgi.py
- Update manage.py

Don't know if it had an impact but LOCALE_PATHS in config/settings/base.py was using a list with a django-environ Path class instead of a string.

## Use case(s) / visualization(s)

It simplifies path handling in settings.