### PR TITLE
Remove gunicorn from installed apps

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -179,10 +179,6 @@ ANYMAIL = {
     "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
 }
 
-# Gunicorn
-# ------------------------------------------------------------------------------
-INSTALLED_APPS += ["gunicorn"]  # noqa F405
-
 {% if cookiecutter.use_whitenoise == 'y' -%}
 # WhiteNoise
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
I can't find the requirement of adding it to INSTALLED_APPS on the
Django or the Gunicorn docs.

https://docs.gunicorn.org/en/latest/run.html?highlight=django#django
https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/gunicorn/

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

I can't find the requirement of adding it to INSTALLED_APPS on the
Django or the Gunicorn docs.

https://docs.gunicorn.org/en/latest/run.html?highlight=django#django
https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/gunicorn/


## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


