### PR TITLE
Remove EMAIL_HOST & EMAIL_PORT with locmem backend

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -48,10 +48,6 @@ TEMPLATES[0]["OPTIONS"]["loaders"] = [  # noqa F405
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
-# https://docs.djangoproject.com/en/dev/ref/settings/#email-host
-EMAIL_HOST = "localhost"
-# https://docs.djangoproject.com/en/dev/ref/settings/#email-port
-EMAIL_PORT = 1025
 
 # Your stuff...
 # ------------------------------------------------------------------------------


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)


These settings should not be required since Django never connects to an
external component when sending email. Instead it's stored in memory.

https://docs.djangoproject.com/en/2.2/topics/email/#in-memory-backend

## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


