### PR TITLE
Add pre-commit for generated Django project, not for Cookiecutter Dja…

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -136,6 +136,7 @@ Listed in alphabetical order.
   Keyvan Mosharraf         `@keyvanm`_
   Krzysztof Szumny         `@noisy`_
   Krzysztof Żuraw          `@krzysztofzuraw`_
+  Leo Wong                 `@leollon`_
   Leo Zhou                 `@glasslion`_
   Leonardo Jimenez         `@xpostudio4`_
   Lin Xianyi               `@iynaix`_
@@ -286,6 +287,7 @@ Listed in alphabetical order.
 .. _@kevgathuku: https://github.com/kevgathuku
 .. _@keyvanm: https://github.com/keyvanm
 .. _@knitatoms: https://github.com/knitatoms
+.. _@leollon: https://github.com/leollon
 .. _@krzysztofzuraw: https://github.com/krzysztofzuraw
 .. _@MathijsHoogland: https://github.com/MathijsHoogland
 .. _@mattayes: https://github.com/mattayes

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ Optional Integrations
 .. _PythonAnywhere: https://www.pythonanywhere.com/
 .. _Traefik: https://traefik.io/
 .. _LetsEncrypt: https://letsencrypt.org/
+.. _pre-commit: https://github.com/pre-commit/pre-commit
 
 Constraints
 -----------
@@ -193,6 +194,7 @@ Answer the prompts with your own desired options_. For example::
     5 - Not open source
     Choose from 1, 2, 3, 4, 5 [1]: 1
     keep_local_envs_in_vcs [y]: y
+    use_pre_commit [n]: n
     debug[n]: n
 
 Enter the project and take a look around::

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -42,6 +42,6 @@
   "use_heroku": "n",
   "use_travisci": "n",
   "keep_local_envs_in_vcs": "y",
-
+  "use_pre_commit": "n",
   "debug": "n"
 }

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -26,6 +26,8 @@ First things first.
 #. Install development requirements: ::
 
     $ pip install -r requirements/local.txt
+    # Optional: install git hook if using pre-commit
+    $ pre-commit install
 
 #. Create a new PostgreSQL database using createdb_: ::
 

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -103,6 +103,14 @@ keep_local_envs_in_vcs:
     is strongly encouraged).
     Note: .env(s) are only utilized when Docker Compose and/or Heroku support is enabled.
 
+use_pre_commit:
+    Indicates that pointing out issues in code on every commit with git,
+    such as missing semicolons, trailing whitespace, sort import statements
+    and debug statements. It is also good for code review while not wasting time with
+    trivial style nitpicks.
+    This option is just relevant for Django project developers,
+    but not for Cookiecutter Django developers.
+
 debug:
     Indicates whether the project should be configured for debugging.
     This option is relevant for Cookiecutter Django developers only.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -279,6 +279,10 @@ def remove_node_dockerfile():
     shutil.rmtree(os.path.join("compose", "local", "node"))
 
 
+def remove_dotpre_commit_config_yaml():
+    os.remove(".pre-commit-config.yaml")
+
+
 def main():
     debug = "{{ cookiecutter.debug }}".lower() == "y"
 
@@ -341,6 +345,9 @@ def main():
 
     if "{{ cookiecutter.use_travisci }}".lower() == "n":
         remove_dottravisyml_file()
+
+    if "{{ cookiecutter.use_pre_commit }}".lower() == "n":
+        remove_dotpre_commit_config_yaml()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -37,6 +37,7 @@ def context():
 @pytest.mark.parametrize("use_sentry", YN_CHOICES, ids=lambda yn: f"sentry:{yn}")
 @pytest.mark.parametrize("use_compressor", YN_CHOICES, ids=lambda yn: f"cmpr:{yn}")
 @pytest.mark.parametrize("use_whitenoise", YN_CHOICES, ids=lambda yn: f"wnoise:{yn}")
+@pytest.mark.parametrize("use_pre_commit", YN_CHOICES, ids=lambda yn: f"precommit:{yn}")
 @pytest.mark.parametrize("cloud_provider", CLOUD_CHOICES, ids=lambda yn: f"cloud:{yn}")
 def context_combination(
     windows,
@@ -47,6 +48,7 @@ def context_combination(
     use_compressor,
     use_whitenoise,
     cloud_provider,
+    use_pre_commit,
 ):
     """Fixture that parametrize the function where it's used."""
     return {
@@ -58,6 +60,7 @@ def context_combination(
         "use_sentry": use_sentry,
         "use_whitenoise": use_whitenoise,
         "cloud_provider": cloud_provider,
+        "use_pre_commit": use_pre_commit,
     }
 
 

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+exclude: .+/migrations/.+\.py
+default_stages: [commit]
+fail_fast: true
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: master
+    hooks:
+      - id: trailing-whitespace
+        files: (^|/){{cookiecutter.project_slug}}/.+\.(py|html|sh|css|js)$
+
+-   repo: local
+    hooks:
+      - id: black
+        name: black
+        entry: black
+        args: [--line-length=80]
+        language: python
+        types: [python]
+        files: (^|/){{cookiecutter.project_slug}}/.+\.py$
+        verbose: true
+
+-   repo: local
+    hooks:
+      - id: flake8
+        name: flake8
+        entry: flake8
+        args: [--max-line-length=120]
+        language: python
+        types: [python]
+        files: (^|/){{cookiecutter.project_slug}}/.+\.py$
+        verbose: true

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -21,6 +21,9 @@ flake8==3.7.8  # https://github.com/PyCQA/flake8
 coverage==4.5.3  # https://github.com/nedbat/coveragepy
 black==19.3b0  # https://github.com/ambv/black
 pylint-django==2.0.11  # https://github.com/PyCQA/pylint-django
+{%- if cookiecutter.use_pre_commit == 'y' %}
+pre-commit==1.17.0  # https://github.com/pre-commit/pre-commit
+{%- endif %}
 {%- if cookiecutter.use_celery == 'y' %}
 pylint-celery==0.3  # https://github.com/PyCQA/pylint-celery
 {%- endif %}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
add pre-commit for generated django project



## Rationale

[//]: # (Why does the project need that?)
`pre-commit` is a tool that can points out issues in code, it is helpful before doing code review, do not have to waste time with trivial style nitpicks.



## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

As far as I know, there is only one case I've seen.
[bk-bcs-saas](https://github.com/Tencent/bk-bcs-saas/blob/master/.pre-commit-config.yaml)
