### PR TITLE
Remove EMAIL_HOST, EMAIL_PORT for console backend

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -28,19 +28,19 @@ CACHES = {
 {% if cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'y' -%}
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-host
 EMAIL_HOST = env("EMAIL_HOST", default="mailhog")
+# https://docs.djangoproject.com/en/dev/ref/settings/#email-port
+EMAIL_PORT = 1025
 {%- elif cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'n' -%}
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-host
 EMAIL_HOST = "localhost"
+# https://docs.djangoproject.com/en/dev/ref/settings/#email-port
+EMAIL_PORT = 1025
 {%- else -%}
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = env(
     "DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )
-# https://docs.djangoproject.com/en/dev/ref/settings/#email-host
-EMAIL_HOST = "localhost"
 {%- endif %}
-# https://docs.djangoproject.com/en/dev/ref/settings/#email-port
-EMAIL_PORT = 1025
 
 # django-debug-toolbar
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
django.core.mail.backends.console.EmailBackend is an in memory backend
so EMAIL_HOST and EMAIL_PORT does not need to be specified in this case.
