### PR TITLE
Add context processor for settings variables

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -187,6 +187,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
+                "{{ cookiecutter.project_slug }}.utils.context_processors.settings_context",
             ],
         },
     }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def settings_context(_request):
+    return {"settings": settings}


### PR DESCRIPTION
This allows for usage of settings variables in templates, e.g

```
{% if settings.USE_ANALYTICS %}
<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ settings.GOOGLE_TAG_MANAGER_ID }}" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->
{% endif %}
```

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)




## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


