### PR TITLE
Fix APPS path when using pytest

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -1,6 +1,7 @@
 """
 Base settings to build other settings files upon.
 """
+import sys
 
 import environ
 
@@ -8,6 +9,9 @@ ROOT_DIR = (
     environ.Path(__file__) - 3
 )  # ({{ cookiecutter.project_slug }}/config/settings/base.py - 3 = {{ cookiecutter.project_slug }}/)
 APPS_DIR = ROOT_DIR.path("{{ cookiecutter.project_slug }}")
+# This allows easy placement of apps within the interior
+# {{ cookiecutter.project_slug }} directory.
+sys.path.append(str(APPS_DIR))
 
 env = environ.Env()
 

--- a/{{cookiecutter.project_slug}}/manage.py
+++ b/{{cookiecutter.project_slug}}/manage.py
@@ -22,9 +22,4 @@ if __name__ == "__main__":
 
         raise
 
-    # This allows easy placement of apps within the interior
-    # {{ cookiecutter.project_slug }} directory.
-    current_path = os.path.dirname(os.path.abspath(__file__))
-    sys.path.append(os.path.join(current_path, "{{ cookiecutter.project_slug }}"))
-
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
Pytest does not use manage.py when executing tests. This means that the
trick we use to append app directories inside of the main project won't
work since the logic exists in manage.py.

If we instead place the same logic in base.py, things work as expected
when running pytest.