### PR TITLE
Add default tests.py file pattern to pytest

### DIFF
--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = --ds=config.settings.test
+python_files = tests.py test_*.py
 {%- if cookiecutter.js_task_runner != 'None' %}
 norecursedirs = node_modules
 {%- endif %}


### PR DESCRIPTION
`./manage.py startapp` generates a tests.py file by default. This is
ignored by pytest unless specified.
