### PR TITLE
Run traefik as non-root user

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
@@ -3,3 +3,10 @@ RUN mkdir -p /etc/traefik/acme
 RUN touch /etc/traefik/acme/acme.json
 RUN chmod 600 /etc/traefik/acme/acme.json
 COPY ./compose/production/traefik/traefik.toml /etc/traefik
+
+RUN addgroup -g 101 -S traefik
+RUN adduser -S -D -H -u 101 -s /sbin/nologin -G traefik -g traefik traefik
+RUN chown -R traefik /etc/traefik
+
+USER traefik
+EXPOSE 8080/tcp 8443/tcp

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.toml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.toml
@@ -5,12 +5,12 @@ defaultEntryPoints = ["http", "https"]
 [entryPoints]
   # http should be redirected to https
   [entryPoints.http]
-  address = ":80"
+  address = ":8080"
     [entryPoints.http.redirect]
     entryPoint = "https"
   # https is the default
   [entryPoints.https]
-  address = ":443"
+  address = ":8443"
     [entryPoints.https.tls]
 
 # Enable ACME (Let's Encrypt): automatic SSL

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -40,8 +40,8 @@ services:
     volumes:
       - production_traefik:/etc/traefik/acme
     ports:
-      - "0.0.0.0:80:80"
-      - "0.0.0.0:443:443"
+      - "0.0.0.0:80:8080"
+      - "0.0.0.0:443:8443"
 
   redis:
     image: redis:5.0


### PR DESCRIPTION
This has been brought up by @westurner, original issue is #1992 

The PR adds a non-root user *traefik* and a *traefik* group and runs the container as this user. This makes it consistent with what we have in `compose/production/django/Dockerfile`.

Care to give it a spin @westurner?