### PR TITLE
Update django-anymail to 7.0.0

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -18,4 +18,4 @@ django-storages[boto3]==1.7.1  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
 django-storages[google]==1.7.1  # https://github.com/jschneier/django-storages
 {%- endif %}
-django-anymail[mailgun]==6.1.0  # https://github.com/anymail/django-anymail
+django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail


### PR DESCRIPTION

This PR updates [django-anymail[mailgun]](https://pypi.org/project/django-anymail) from **6.1.0** to **7.0.0**.





---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
