### PR TITLE
Add StimulusJS integration.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -121,6 +121,7 @@ Listed in alphabetical order.
   Jan Van Bruggen          `@jvanbrug`_
   Jelmer Draaijer          `@foarsitter`_
   Jens Nilsson             `@phiberjenz`_
+  Jerome Caisip            `@jeromecaisip`_
   Jerome Leclanche         `@jleclanche`_                @Adys
   Jimmy Gitonga            `@afrowave`_                  @afrowave
   John Cass                `@jcass77`_                   @cass_john
@@ -276,6 +277,7 @@ Listed in alphabetical order.
 .. _@jangeador: https://github.com/jangeador
 .. _@jazztpt: https://github.com/jazztpt
 .. _@jcass77: https://github.com/jcass77
+.. _@jeromecaisip: https://github.com/jeromecaisip
 .. _@jleclanche: https://github.com/jleclanche
 .. _@juliocc: https://github.com/juliocc
 .. _@jvanbrug: https://github.com/jvanbrug

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -35,6 +35,7 @@
   ],
   "custom_bootstrap_compilation": "n",
   "use_compressor": "n",
+  "use_stimulusJS": "n",
   "use_celery": "n",
   "use_mailhog": "n",
   "use_sentry": "n",

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -78,6 +78,9 @@ custom_bootstrap_compilation:
 use_compressor:
     Indicates whether the project should be configured to use `Django Compressor`_.
 
+use_stimulusJS:
+    Indicates whether the project should be configured to use `Stimulus JS`_.
+
 use_celery:
     Indicates whether the project should be configured to use Celery_.
 
@@ -138,3 +141,6 @@ debug:
 .. _Heroku: https://github.com/heroku/heroku-buildpack-python
 
 .. _Travis CI: https://travis-ci.org/
+
+.. _Stimulus JS: https://stimulusjs.org/
+

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -279,6 +279,10 @@ def remove_node_dockerfile():
     shutil.rmtree(os.path.join("compose", "local", "node"))
 
 
+def remove_stimulus_js_files():
+    shutil.rmtree(os.path.join("{{cookiecutter.project_slug}}", "static", "{{cookiecutter.project_slug}}"))
+
+
 def main():
     debug = "{{ cookiecutter.debug }}".lower() == "y"
 
@@ -341,6 +345,9 @@ def main():
 
     if "{{ cookiecutter.use_travisci }}".lower() == "n":
         remove_dottravisyml_file()
+
+    if "{{ cookiecutter.use_stimulusJS }}".lower() == "n":
+        remove_stimulus_js_files()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "static",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "webpack --watch --config webpack.config.dev.js",
+    "build": "webpack --config webpack.config.prod.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "axios": "^0.19.0",
+    "babel-loader": "^8.0.6",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "stimulus": "^1.1.1",
+    "webpack": "^4.34.0",
+    "webpack-cli": "^3.3.4"
+  },
+  "dependencies": {}
+}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/src/pages/home/controllers/sample_controller.js
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/src/pages/home/controllers/sample_controller.js
@@ -1,0 +1,5 @@
+import {Controller} from "stimulus"
+
+export default class extends Controller  {
+
+}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/src/pages/home/index.js
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/src/pages/home/index.js
@@ -1,0 +1,6 @@
+import {Application} from "stimulus"
+import {definitionsFromContext} from "stimulus/webpack-helpers"
+
+const application = Application.start();
+const context = require.context("./controllers", true, /\.js$/);
+application.load(definitionsFromContext(context));

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/webpack.config.dev.js
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/webpack.config.dev.js
@@ -1,0 +1,51 @@
+const path = require('path');
+
+module.exports = {
+    entry: {
+        'home': './src/pages/home/index.js',
+    },
+    output: {
+        filename: '[name].js',
+        path: path.resolve(__dirname, 'dist'),
+        publicPath: 'static/'
+    },
+    mode: 'development',
+    optimization: {
+        splitChunks: {
+            minSize: 0,
+            cacheGroups: {
+                commons: {
+                    name: 'commons',
+                    chunks: 'all',
+                }
+            }
+        }
+    },
+    module: {
+        rules: [
+            {
+                test: /\.(png|jpg)$/,
+                use: [
+                    'file-loader'
+                ]
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    'css-loader',
+                ]
+            },
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: "babel-loader",
+                    options: {
+                        presets: ['@babel/env'],
+                        plugins: ['transform-class-properties']
+                    }
+                }
+            },
+        ]
+    }
+};

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/webpack.config.prod.js
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/{{cookiecutter.project_slug}}/webpack.config.prod.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const dev_exports = require('./webpack.config.dev');
+
+dev_exports['mode'] = 'production';
+module.exports = dev_exports;


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
I am proposing of adding an option to use [stimulus JS](https://stimulusjs.org/) and setup the integration via webpack for those who usually use it and those who wants to get started using this library.

## Rationale

[//]: # (Why does the project need that?)
Because this could help devs who wants to start building multiple page applications
using stimulusJS, but don't have an idea of how to integrate the library in order to start. This could
also help awareness of this library and help devs with limited javascript experience to write better JS code.

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

I typically use this library, [stimulusJS](https://stimulusjs.org/), in order for me to write readable and maintainable javascript when building multiple page application. 
