### PR TITLE
Fix #2249 -- Broken static files with whitenoise=n & cloud_prov…

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -59,3 +59,12 @@ if "{{ cookiecutter.use_docker }}".lower() == "n":
                     )
                     + TERMINATOR
                 )
+
+if (
+    "{{ cookiecutter.use_whitenoise }}".lower() == "n"
+    and "{{ cookiecutter.cloud_provider }}" == "None"
+):
+    print(
+        "You should either use Whitenoise or select a Cloud Provider to serve static files"
+    )
+    sys.exit(1)

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -165,6 +165,7 @@ def test_invalid_slug(cookies, context, slug):
 
 
 def test_no_whitenoise_and_no_cloud_provider(cookies, context):
+    """It should not generate project if neither whitenoise or cloud provider are set"""
     context.update({"use_whitenoise": "n", "cloud_provider": "None"})
     result = cookies.bake(extra_context=context)
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -49,6 +49,11 @@ def context_combination(
     cloud_provider,
 ):
     """Fixture that parametrize the function where it's used."""
+    if cloud_provider == "None":
+        # Either of the two should be set for serving static files, so if cloud provider
+        # is not set, we force Whitenoise to be set
+        use_whitenoise = "y"
+
     return {
         "windows": windows,
         "use_docker": use_docker,
@@ -157,3 +162,10 @@ def test_invalid_slug(cookies, context, slug):
 
     assert result.exit_code != 0
     assert isinstance(result.exception, FailedHookException)
+
+
+def test_no_whitenoise_and_no_cloud_provider(cookies, context):
+    context.update({"use_whitenoise": "n", "cloud_provider": "None"})
+    result = cookies.bake(extra_context=context)
+
+    assert result.exit_code == 1

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -169,4 +169,5 @@ def test_no_whitenoise_and_no_cloud_provider(cookies, context):
     context.update({"use_whitenoise": "n", "cloud_provider": "None"})
     result = cookies.bake(extra_context=context)
 
-    assert result.exit_code == 1
+    assert result.exit_code != 0
+    assert isinstance(result.exception, FailedHookException)


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Fixes https://github.com/pydanny/cookiecutter-django/issues/2249


## Rationale

[//]: # (Why does the project need that?)

If the user chooses use_whitenoise=n & cloud_provider=None, it should not be allowed and show an error when trying to generate the project.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


