### PR TITLE
Pin Traefik Docker image to v1

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:alpine
+FROM traefik:1.7-alpine
 RUN mkdir -p /etc/traefik/acme
 RUN touch /etc/traefik/acme/acme.json
 RUN chmod 600 /etc/traefik/acme/acme.json


### PR DESCRIPTION
## Description

This is to resolve the problem raised by @demestav in #2258 until we do the required changes to update to v2.

Fixes #2258 

## Rationale

The current config is incompatible
