### PR TITLE
Prevent collectfast from guessing a wrong strategy

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -200,6 +200,7 @@ Listed in alphabetical order.
   William Archinal         `@archinal`_
   Xaver Y.R. Chen          `@yrchen`_                   @yrchen
   Yaroslav Halchenko
+  Yuchen Xie               `@mapx`_
 ========================== ============================ ==============
 
 .. _@a7p: https://github.com/a7p
@@ -291,6 +292,7 @@ Listed in alphabetical order.
 .. _@knitatoms: https://github.com/knitatoms
 .. _@krzysztofzuraw: https://github.com/krzysztofzuraw
 .. _@MathijsHoogland: https://github.com/MathijsHoogland
+.. _@mapx: https://github.com/mapx
 .. _@mattayes: https://github.com/mattayes
 .. _@menzenski: https://github.com/menzenski
 .. _@mfwarren: https://github.com/mfwarren

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -104,9 +104,11 @@ GS_DEFAULT_ACL = "publicRead"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 {% elif cookiecutter.cloud_provider == 'AWS' -%}
 STATICFILES_STORAGE = "config.settings.production.StaticRootS3Boto3Storage"
+COLLECTFAST_STRATEGY = "collectfast.strategies.boto3.Boto3Strategy"
 STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
 {% elif cookiecutter.cloud_provider == 'GCP' -%}
 STATICFILES_STORAGE = "config.settings.production.StaticRootGoogleCloudStorage"
+COLLECTFAST_STRATEGY = "collectfast.strategies.gcloud.GoogleCloudStrategy"
 STATIC_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/static/"
 {% endif -%}
 


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description
This PR fixes the following issue raised when one starts Django (with AWS) docker service:
![Screenshot from 2019-10-22 08-16-36](https://user-images.githubusercontent.com/4576282/67255746-2eecb200-f4b6-11e9-9d70-e4f0b680972e.png)


## Rationale
If `COLLECTFAST_STRATEGY` is not provided in `settings`, `collectfast` has to guess a "strategy". For the case with AWS, it guesses `BotoStrategy` in stead of `S3Boto3Storage`, which is a wrong decision as we `pip install django-storages[boto3]` (`boto3` in favor of `boto`). 

Setting `COLLECTFAST_STRATEGY` is also encouraged as `collectfast` is not going to guess the strategy in the future.

Ref:
* https://github.com/antonagestam/collectfast/blob/f37dd1faa2046a2ebb88c098eb03e56a95534ec6/collectfast/management/commands/collectstatic.py#L33
* https://github.com/antonagestam/collectfast/blob/f37dd1faa2046a2ebb88c098eb03e56a95534ec6/collectfast/strategies/base.py#L170


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


