### PR TITLE
Added more settings to .editorconfig to run isort and have blac…

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -73,6 +73,7 @@ Listed in alphabetical order.
   Bo Lopker                `@blopker`_
   Bouke Haarsma
   Brent Payne              `@brentpayne`_               @brentpayne
+  Bruce Olivier            `@bolivierjr`_
   Burhan Khalid            `@burhan`_                   @burhan
   Caio Ariede              `@caioariede`_               @caioariede
   Carl Johnson             `@carlmjohnson`_             @carlmjohnson
@@ -225,6 +226,7 @@ Listed in alphabetical order.
 .. _@bloodpet: https://github.com/bloodpet
 .. _@blopker: https://github.com/blopker
 .. _@bogdal: https://github.com/bogdal
+.. _@bolivierjr: https://github.com/bolivierjr
 .. _@brentpayne: https://github.com/brentpayne
 .. _@btknu: https://github.com/btknu
 .. _@burhan: https://github.com/burhan

--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -13,10 +13,16 @@ indent_style = space
 indent_size = 4
 
 [*.py]
-line_length=120
-known_first_party={{ cookiecutter.project_slug }}
-multi_line_output=3
-default_section=THIRDPARTY
+line_length = 120
+known_first_party = {{ cookiecutter.project_slug }}
+multi_line_output = 3
+default_section = THIRDPARTY
+recursive = true
+skip = venv/
+skip_glob = **/migrations/*.py
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
 
 [*.{html,css,scss,json,yml}]
 indent_style = space


### PR DESCRIPTION
…atibility.

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Updated .editorconfig to now be able to just run "isort" in root directory and is compatible with the black formatter with the include_trailing_comma, force_grip_wrap, and use_parentheses settings.



## Rationale

[//]: # (Why does the project need that?)
Easier to use the already put in place isort command now that'll sort your imports for you without having to run other flags or exclusions.

## Related Issues

#2123 