### PR TITLE
Use pytest-django --reuse-db for faster tests

### DIFF
--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test
+addopts = --ds=config.settings.test --reuse-db
 python_files = tests.py test_*.py
 {%- if cookiecutter.js_task_runner != 'None' %}
 norecursedirs = node_modules


### PR DESCRIPTION
Pytest-django allows you to re-use database setups between tests for
quicker test runs. This is especially useful for large projects with many
migrations.

For example, here's a project of mine with 40+ migrations:

with --reuse-db
```
pytest --reuse-db  2.54s user 0.35s system 108% cpu 2.669 total
```

without --reuse-db
```
pytest 7.40s user 0.34s system 50% cpu 15.240 total
```

Caveat: if your model happens to change you need to manually --create-db
to ensure migrations are applied.

https://pytest-django.readthedocs.io/en/latest/database.html#reuse-db-reuse-the-testing-database-between-test-runs

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)




## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


