### PR TITLE
Add an option to choose AWS SES for email

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -160,6 +160,7 @@ Listed in alphabetical order.
   Meghan Heintz            `@dot2dotseurat`_
   Mesut Yılmaz             `@myilmaz`_
   Michael Gecht            `@mimischi`_                  @_mischi
+  Michael Karamuth         `@joshtensibly`_               
   Min ho Kim               `@minho42`_
   mozillazg                `@mozillazg`_
   Nico Stefani             `@nicolas471`_                @moby_dick91

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,22 +17,10 @@
   "windows": "n",
   "use_pycharm": "n",
   "use_docker": "n",
-  "postgresql_version": [
-    "11.3",
-    "10.8",
-    "9.6",
-    "9.5",
-    "9.4"
-  ],
-  "js_task_runner": [
-    "None",
-    "Gulp"
-  ],
-  "cloud_provider": [
-    "AWS",
-    "GCP",
-    "None"
-  ],
+  "postgresql_version": ["11.3", "10.8", "9.6", "9.5", "9.4"],
+  "js_task_runner": ["None", "Gulp"],
+  "cloud_provider": ["AWS", "GCP", "None"],
+  "email_provider": ["SES", "Mailgun"],
   "custom_bootstrap_compilation": "n",
   "use_compressor": "n",
   "use_celery": "n",

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -186,7 +186,7 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]  # noqa F405
-{%- if cookiecutter.cloud_provider == 'AWS' %}
+{%- if cookiecutter.email_provider == 'SES' %}
 # Use boto3 credentials
 # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
 EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -182,10 +182,15 @@ EMAIL_SUBJECT_PREFIX = env(
 # Django Admin URL regex.
 ADMIN_URL = env("DJANGO_ADMIN_URL")
 
-# Anymail (Mailgun)
+# Anymail
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]  # noqa F405
+{%- if cookiecutter.cloud_provider == 'AWS' %}
+# Use boto3 credentials
+# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
+{% else %}
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {
@@ -193,6 +198,7 @@ ANYMAIL = {
     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
     "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
 }
+{% endif -%}
 
 {% if cookiecutter.use_compressor == 'y' -%}
 # django-compressor

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -19,7 +19,7 @@ django-storages[boto3]==1.8  # https://github.com/jschneier/django-storages
 django-storages[google]==1.8  # https://github.com/jschneier/django-storages
 {%- endif %}
 
-{%- if cookiecutter.cloud_provider == 'AWS' %}
+{%- if cookiecutter.email_provider == 'SES' %}
 django-anymail[amazon_ses]==7.0.0  # https://github.com/anymail/django-anymail
 {%- else %}
 django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -18,4 +18,9 @@ django-storages[boto3]==1.8  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
 django-storages[google]==1.8  # https://github.com/jschneier/django-storages
 {%- endif %}
+
+{%- if cookiecutter.cloud_provider == 'AWS' %}
+django-anymail[amazon_ses]==7.0.0  # https://github.com/anymail/django-anymail
+{%- else %}
 django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail
+{%- endif %}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Add the option to choose SES as email provider. This will install `django-anymail[amazon_ses]` and set the `EMAIL_BACKEND` to `anymail.backends.amazon_ses.EmailBackend`



## Rationale

[//]: # (Why does the project need that?)
To allow users to start a project with SES for email instead of Mailgun of they wish.



## Use case(s) / visualization(s)
Send emails with SES.
[//]: # ("Better to see something once than to hear about it a thousand times.")


