### PR TITLE
Make update form button look like a button

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -116,6 +116,7 @@ Listed in alphabetical order.
   Gilbishkosma             `@Gilbishkosma`_
   Hamish Durkin            `@durkode`_
   Hana Quadara             `@hanaquadara`_
+  Harry Moreno             `@morenoh149`_                @morenoh149
   Harry Percival           `@hjwp`_
   Hendrik Schneider        `@hendrikschneider`_
   Henrique G. G. Pereira   `@ikkebr`_
@@ -307,6 +308,7 @@ Listed in alphabetical order.
 .. _@minho42: https://github.com/minho42
 .. _@mjsisley: https://github.com/mjsisley
 .. _@mknapper1: https://github.com/mknapper1
+.. _@morenoh149: https://github.com/morenoh149
 .. _@mostaszewski: https://github.com/mostaszewski
 .. _@mozillazg: https://github.com/mozillazg
 .. _@mrcoles: https://github.com/mrcoles

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/users/user_form.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/users/user_form.html
@@ -10,7 +10,7 @@
     {{ form|crispy }}
     <div class="control-group">
       <div class="controls">
-        <button type="submit" class="btn">Update</button>
+        <button type="submit" class="btn btn-primary">Update</button>
       </div>
     </div>
   </form>


### PR DESCRIPTION
without `btn-primary` the button looks like some floating text.

[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

make update button look like a button




## Rationale

it is confusing to reach this page and not see "Update" within a button style.

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
before
![Screen Shot 2019-11-25 at 4 43 52 PM](https://user-images.githubusercontent.com/587438/69580607-e3409300-0fa2-11ea-85c3-8f03402242bf.png)
after
![Screen Shot 2019-11-25 at 4 43 39 PM](https://user-images.githubusercontent.com/587438/69580624-ec316480-0fa2-11ea-968b-61f409cd74d2.png)

