### PR TITLE
Add option to choose CI tool

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -40,7 +40,11 @@
   "use_sentry": "n",
   "use_whitenoise": "n",
   "use_heroku": "n",
-  "use_travisci": "n",
+  "ci_tool": [
+    "None",
+    "Travis",
+    "Gitlab"
+  ],
   "keep_local_envs_in_vcs": "y",
 
   "debug": "n"

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -94,8 +94,12 @@ use_heroku:
     Indicates whether the project should be configured so as to be deployable
     to Heroku_.
 
-use_travisci:
-    Indicates whether the project should be configured to use `Travis CI`_.
+ci_tool:
+    Select a CI tool for running tests. The choices are:
+
+    1. None
+    2. Travis_
+    3. Gitlab_
 
 keep_local_envs_in_vcs:
     Indicates whether the project's ``.envs/.local/`` should be kept in VCS
@@ -138,3 +142,6 @@ debug:
 .. _Heroku: https://github.com/heroku/heroku-buildpack-python
 
 .. _Travis CI: https://travis-ci.org/
+
+.. _GitLab CI: https://docs.gitlab.com/ee/ci/
+

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -70,7 +70,7 @@ def remove_heroku_files():
     for file_name in file_names:
         if (
             file_name == "requirements.txt"
-            and "{{ cookiecutter.use_travisci }}".lower() == "y"
+            and "{{ cookiecutter.ci_tool }}".lower() == "travis"
         ):
             # don't remove the file if we are using travisci but not using heroku
             continue
@@ -103,6 +103,10 @@ def remove_celery_files():
 
 def remove_dottravisyml_file():
     os.remove(".travis.yml")
+
+
+def remove_dotgitlabciyml_file():
+    os.remove(".gitlab-ci.yml")
 
 
 def append_to_project_gitignore(path):
@@ -349,8 +353,11 @@ def main():
         if "{{ cookiecutter.use_docker }}".lower() == "y":
             remove_celery_compose_dirs()
 
-    if "{{ cookiecutter.use_travisci }}".lower() == "n":
+    if "{{ cookiecutter.ci_tool }}".lower() != "travis":
         remove_dottravisyml_file()
+
+    if "{{ cookiecutter.ci_tool }}".lower() != "gitlab":
+        remove_dotgitlabciyml_file()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -1,0 +1,33 @@
+stages:
+  - lint
+  - test
+
+variables:
+  POSTGRES_USER: '{{ cookiecutter.project_slug }}'
+  POSTGRES_PASSWORD: ''
+  POSTGRES_DB: 'test_{{ cookiecutter.project_slug }}'
+
+flake8:
+  stage: lint
+  image: python:3.7-alpine
+  before_script:
+    - pip install -q flake8
+  script:
+    - flake8
+
+pytest:
+  stage: test
+  image: python:3.7
+  tags:
+    - docker
+  services:
+    - postgres:11
+  variables:
+    DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
+
+  before_script:
+    - pip install -r requirements/local.txt
+
+  script:
+    - pytest
+


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Added single option for choosing ci tool + added simple gitlab-ci config.



## Rationale

[//]: # (Why does the project need that?)
There is no reason to use multiple ci tools in one project, so we can use one option to choose exact tool we are going to use, instead of adding multiple boolean options.



## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
For example, If I store my code in GitHub, I use Travis CI because there is a convenient integration between these two platforms. But if I want to use GitLab - I use built-in GitLab CI tool.

Fixes #607 