### PR TITLE
Speed up django image build process, and reduce its size

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -57,12 +57,10 @@ RUN chmod +x /start-flower
 {%- endif %}
 
 {%- if cookiecutter.js_task_runner == 'Gulp' %}
-COPY --from=client-builder /app /app
+COPY --from=client-builder --chown=django:django /app /app
 {% else %}
-COPY . /app
+COPY --chown=django:django . /app
 {%- endif %}
-
-RUN chown -R django /app
 
 USER django
 


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing?)
Improve Django image build process, and reduce its size.

## Rationale
As @iMerica mentioned in https://github.com/pydanny/cookiecutter-django/issues/1157, this modification reduces hundreds of megabytes from the Docker image.
We also found the new build process a lot faster. The command `RUN chown -R django /app` takes too much time.