### PR TITLE
Add django.middleware.common.BrokenLinkEmailsMiddleware

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -140,6 +140,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/howto/error-reporting/#errors

> If those conditions are met, Django will email the users listed in the
> MANAGERS setting whenever your code raises a 404 and the request has a
> referer. It doesn’t bother to email for 404s that don’t have a referer –
> those are usually just people typing in broken URLs or broken Web bots.
> It also ignores 404s when the referer is equal to the requested URL,
> since this behavior is from broken Web bots too.
