### PR TITLE
Add sane django-extensions defaults

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -256,6 +256,16 @@ LOGGING = {
     "root": {"level": "INFO", "handlers": ["console"]},
 }
 
+# django-extensions
+SHELL_PLUS_PRINT_SQL_TRUNCATE = 10000
+SHELL_PLUS_SQLPARSE_FORMAT_KWARGS = dict(
+    reindent_aligned=True,
+    truncate_strings=500
+)
+SHELL_PLUS_MODEL_IMPORTS_RESOLVER = (
+    "django_extensions.collision_resolvers.AppNameSuffixCustomOrderCR"
+)
+
 {% if cookiecutter.use_celery == 'y' -%}
 # Celery
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
1. When running shell_plus with sql query printing enabled it truncates
queries by default.

```sh
./manage.py shell_plus --print-sql
```

Change the truncate setting to present longer strings and to format
[sqlparse](https://pypi.org/project/sqlparse/) output.

2. When two modules of the same name are imported the last one will
persist. By using collision resolvers we make sure that both are
imported with different suffixes.
