### PR TITLE
Remove mypy defaults and set django-stubs setting

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -9,12 +9,13 @@ exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
 [mypy]
 python_version = 3.7
 check_untyped_defs = True
-ignore_errors = False
 ignore_missing_imports = True
-strict_optional = True
 warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unused_configs = True
+
+[mypy.plugins.django-stubs]
+django_settings_module = config.settings.test
 
 [mypy-*.migrations.*]
 # Django migrations should not produce any errors:


### PR DESCRIPTION
https://mypy.readthedocs.io/en/latest/config_file.html

ignore_errors = False
strict_optional = True

Are both set to these values by default. No need to set them in the
config.

```toml
[mypy.plugins.django-stubs]
django_settings_module = config.settings.local
```
mypy.plugins.django-stubs requires django_settings_module to be set.
https://github.com/typeddjango/django-stubs#configuration
