### PR TITLE
Add Debian 10 (buster) OS dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/utility/requirements-buster.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-buster.apt
@@ -1,0 +1,23 @@
+##basic build dependencies of various Django apps for Debian Jessie 10.x
+#build-essential metapackage install: make, gcc, g++,
+build-essential
+#required to translate
+gettext
+python3-dev
+
+##shared dependencies of:
+##Pillow, pylibmc
+zlib1g-dev
+
+##Postgresql and psycopg2 dependencies
+libpq-dev
+
+##Pillow dependencies
+libtiff5-dev
+libjpeg62-turbo-dev
+libfreetype6-dev
+liblcms2-dev
+libwebp-dev
+
+##django-extensions
+libgraphviz-dev


### PR DESCRIPTION
## Description

They are all checked. Same packages names as bionic, except for `libjpeg`.
