### PR TITLE
Bumped runtime for heroku.

### DIFF
--- a/{{cookiecutter.project_slug}}/runtime.txt
+++ b/{{cookiecutter.project_slug}}/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.4
+python-3.7.6


### PR DESCRIPTION
Python has released a security update! Please consider upgrading to python-3.7.6
Learn More: https://devcenter.heroku.com/articles/python-runtimes