### PR TITLE
Fix failing mypy tests in users app with django-stubs (#2395)

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -154,7 +154,7 @@ MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/media/"
 # TEMPLATES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#templates
-TEMPLATES[0]["OPTIONS"]["loaders"] = [  # noqa F405
+TEMPLATES[0]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
     (
         "django.template.loaders.cached.Loader",
         [

--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -32,7 +32,7 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # TEMPLATES
 # ------------------------------------------------------------------------------
-TEMPLATES[0]["OPTIONS"]["loaders"] = [  # noqa F405
+TEMPLATES[0]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
     (
         "django.template.loaders.cached.Loader",
         [

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -12,6 +12,7 @@ psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 # Testing
 # ------------------------------------------------------------------------------
 mypy==0.761  # https://github.com/python/mypy
+django-stubs==1.3.1  # https://github.com/typeddjango/django-stubs
 pytest==5.3.1  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar
 

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -13,6 +13,7 @@ ignore_missing_imports = True
 warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unused_configs = True
+plugins = mypy_django_plugin.main
 
 [mypy.plugins.django-stubs]
 django_settings_module = config.settings.test

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
@@ -1,7 +1,7 @@
 import pytest
-from django.conf import settings
 from django.test import RequestFactory
 
+from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
 
 
@@ -11,7 +11,7 @@ def media_storage(settings, tmpdir):
 
 
 @pytest.fixture
-def user() -> settings.AUTH_USER_MODEL:
+def user() -> User:
     return UserFactory()
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_models.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_models.py
@@ -1,8 +1,9 @@
 import pytest
-from django.conf import settings
+
+from {{ cookiecutter.project_slug }}.users.models import User
 
 pytestmark = pytest.mark.django_db
 
 
-def test_user_get_absolute_url(user: settings.AUTH_USER_MODEL):
+def test_user_get_absolute_url(user: User):
     assert user.get_absolute_url() == f"/users/{user.username}/"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
@@ -1,11 +1,12 @@
 import pytest
-from django.conf import settings
 from django.urls import reverse, resolve
+
+from {{ cookiecutter.project_slug }}.users.models import User
 
 pytestmark = pytest.mark.django_db
 
 
-def test_detail(user: settings.AUTH_USER_MODEL):
+def test_detail(user: User):
     assert (
         reverse("users:detail", kwargs={"username": user.username})
         == f"/users/{user.username}/"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -1,7 +1,7 @@
 import pytest
-from django.conf import settings
 from django.test import RequestFactory
 
+from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.views import UserRedirectView, UserUpdateView
 
 pytestmark = pytest.mark.django_db
@@ -16,9 +16,7 @@ class TestUserUpdateView:
         https://github.com/pytest-dev/pytest-django/pull/258
     """
 
-    def test_get_success_url(
-        self, user: settings.AUTH_USER_MODEL, request_factory: RequestFactory
-    ):
+    def test_get_success_url(self, user: User, request_factory: RequestFactory):
         view = UserUpdateView()
         request = request_factory.get("/fake-url/")
         request.user = user
@@ -27,9 +25,7 @@ class TestUserUpdateView:
 
         assert view.get_success_url() == f"/users/{user.username}/"
 
-    def test_get_object(
-        self, user: settings.AUTH_USER_MODEL, request_factory: RequestFactory
-    ):
+    def test_get_object(self, user: User, request_factory: RequestFactory):
         view = UserUpdateView()
         request = request_factory.get("/fake-url/")
         request.user = user
@@ -40,9 +36,7 @@ class TestUserUpdateView:
 
 
 class TestUserRedirectView:
-    def test_get_redirect_url(
-        self, user: settings.AUTH_USER_MODEL, request_factory: RequestFactory
-    ):
+    def test_get_redirect_url(self, user: User, request_factory: RequestFactory):
         view = UserRedirectView()
         request = request_factory.get("/fake-url")
         request.user = user


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

Fixes #2395 

Now that the type resolution of the user model works, we also need to add `django-stubs` as a requirement for the local virtualenv to help mypy with django's model meta magic.

Add `plugins = mypy_django_plugin.main` to the mypy section of the `setup.cfg` as indicated by the `django-stubs` docs.



