### PR TITLE
Assuming DTL to be the last instead of first template engine in…

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -71,6 +71,7 @@ Listed in alphabetical order.
   Benjamin Abel
   Bert de Miranda          `@bertdemiranda`_
   Bo Lopker                `@blopker`_
+  Bo Peng                  `@BoPeng`_
   Bouke Haarsma
   Brent Payne              `@brentpayne`_               @brentpayne
   Bruce Olivier            `@bolivierjr`_
@@ -235,6 +236,7 @@ Listed in alphabetical order.
 .. _@blopker: https://github.com/blopker
 .. _@bogdal: https://github.com/bogdal
 .. _@bolivierjr: https://github.com/bolivierjr
+.. _@BoPeng: https://github.com/BoPeng
 .. _@brentpayne: https://github.com/brentpayne
 .. _@btknu: https://github.com/btknu
 .. _@burhan: https://github.com/burhan

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -154,7 +154,7 @@ MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/media/"
 # TEMPLATES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#templates
-TEMPLATES[0]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
+TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
     (
         "django.template.loaders.cached.Loader",
         [


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Add `loaders` option to the last instead of first engine in `TEMPLATES` settings.

## Rationale

[//]: # (Why does the project need that?)


The following line of code

https://github.com/pydanny/cookiecutter-django/blob/ca90ac1c9315dea9a90c56d18b2f8dd828306ac1/%7B%7Bcookiecutter.project_slug%7D%7D/config/settings/production.py#L157

adds option `loaders` to `TEMPLATES`, which assumes a DTL engine.

However, if users decide to use a jinja2 engine, they will almost surely put the jinja2 engine before the DTL engine so that django will search for a jinja2 template before searching for DTL template. This makes sure that jinja2 has the priority and allows the use jinja2 templates to override system DTL templates. This practice has been recommended for all online tutorials (e.g. [this](https://stackoverflow.com/questions/30701631/how-to-use-jinja2-as-a-templating-engine-in-django-1-8)).

In this case, the aforementioned code causes a problem in that it adds the `loaders` option to the `jinja2` engine, causing it to fail. 

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

The setting breaks a typical configuration with jinja2 template engine.

```
TEMPLATES = [

    {
        'BACKEND': 'django.template.backends.jinja2.Jinja2',
        'DIRS': [os.path.join(BASE_DIR, 'templates/jinja2')],
        'APP_DIRS': True,
        'OPTIONS': {'environment': 'myproject.jinja2.Environment',}, 
    },
    {
        'BACKEND': 'django.template.backends.django.DjangoTemplates',
        'DIRS': [],
        'APP_DIRS': True,
        'OPTIONS': {
        'context_processors': [
            'django.template.context_processors.debug',
            'django.template.context_processors.request',
            'django.contrib.auth.context_processors.auth',
            'django.contrib.messages.context_processors.messages',
           ],
        },
    },
]
```

