### PR TITLE
Fix loaders option in test environment as well

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -32,7 +32,7 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # TEMPLATES
 # ------------------------------------------------------------------------------
-TEMPLATES[0]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
+TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
     (
         "django.template.loaders.cached.Loader",
         [


### PR DESCRIPTION
#2400 fixes `production.py`

https://github.com/pydanny/cookiecutter-django/blob/a5298e02426b0b1fb27cced085d28f75a24e3d0b/%7B%7Bcookiecutter.project_slug%7D%7D/config/settings/production.py#L157

This one fixes `test.py`.

https://github.com/pydanny/cookiecutter-django/blob/a5298e02426b0b1fb27cced085d28f75a24e3d0b/%7B%7Bcookiecutter.project_slug%7D%7D/config/settings/test.py#L35


@browniebroke Please merge.