### PR TITLE
Merge pull request #2406 from BoPeng/master

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -32,7 +32,7 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # TEMPLATES
 # ------------------------------------------------------------------------------
-TEMPLATES[0]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
+TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
     (
         "django.template.loaders.cached.Loader",
         [

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -12,14 +12,18 @@ class UserFactory(DjangoModelFactory):
 
     @post_generation
     def password(self, create: bool, extracted: Sequence[Any], **kwargs):
-        password = extracted if extracted else Faker(
-            "password",
-            length=42,
-            special_chars=True,
-            digits=True,
-            upper_case=True,
-            lower_case=True,
-        ).generate(extra_kwargs={})
+        password = (
+            extracted
+            if extracted
+            else Faker(
+                "password",
+                length=42,
+                special_chars=True,
+                digits=True,
+                upper_case=True,
+                lower_case=True,
+            ).generate(extra_kwargs={})
+        )
         self.set_password(password)
 
     class Meta:


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

`UserFactory` ignores user-provided password so `client` cannot use it to log in. The following does not work

```
UserFactory(username='bob', password='password')
client.login(username='bob', password='password')
```
because `UserFactory` always set a randomly generated password.


## Rationale

[//]: # (Why does the project need that?)

Whereas it is understandable that `user` fixture always have random password, direct use of `UserFactory(username, password)` should not silently ignore `password`, which causes confusion when users use `client.login()` to login with the same password.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

#2405 has some a use case.

Disclaimer: I am not an expert on `factory_boy`. It seems that `create` should be used in this function to determine if the factory is called as `UserFactory` or `UserFactory.create`.

Fixes #2405 