### PR TITLE
boto is required for boto3 to work

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -14,7 +14,7 @@ sentry-sdk==0.14.1  # https://github.com/getsentry/sentry-python
 # Django
 # ------------------------------------------------------------------------------
 {%- if cookiecutter.cloud_provider == 'AWS' %}
-django-storages[boto3]==1.8  # https://github.com/jschneier/django-storages
+django-storages[boto,boto3]==1.8  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
 django-storages[google]==1.8  # https://github.com/jschneier/django-storages
 {%- endif %}


### PR DESCRIPTION
## Description

My website yields the following message when using AWS:

```
django_1        | Traceback (most recent call last):
django_1        |   File "/usr/local/lib/python3.7/site-packages/storages/backends/s3boto.py", line 25, in <module>
django_1        |     from boto import __version__ as boto_version
django_1        | ModuleNotFoundError: No module named 'boto'
django_1        | 
django_1        | During handling of the above exception, another exception occurred:
django_1        | 
django_1        | Traceback (most recent call last):
django_1        |   File "/usr/local/lib/python3.7/site-packages/health_check/storage/backends.py", line 65, in check_status
django_1        |     file_name = self.check_save(file_name, file_content)
django_1        |   File "/usr/local/lib/python3.7/site-packages/health_check/storage/backends.py", line 40, in check_save
django_1        |     storage = self.get_storage()
django_1        |   File "/usr/local/lib/python3.7/site-packages/health_check/storage/backends.py", line 29, in get_storage
django_1        |     return get_storage_class(self.storage)()
django_1        |   File "/usr/local/lib/python3.7/site-packages/django/core/files/storage.py", line 358, in get_storage_class
django_1        |     return import_string(import_path or settings.DEFAULT_FILE_STORAGE)
django_1        |   File "/usr/local/lib/python3.7/site-packages/django/utils/module_loading.py", line 17, in import_string
django_1        |     module = import_module(module_path)
django_1        |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
django_1        |     return _bootstrap._gcd_import(name[level:], package, level)
django_1        |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
django_1        |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
django_1        |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
django_1        |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
django_1        |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
django_1        |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
django_1        |   File "/usr/local/lib/python3.7/site-packages/storages/backends/s3boto.py", line 31, in <module>
django_1        |     raise ImproperlyConfigured("Could not load Boto's S3 bindings.\n"
```

Although not anywhere documented, it turns out that `boto` is required for `boto3` to work.


https://github.com/jschneier/django-storages/blob/1ba084640238725c9ea28e43fe099578a9df9a98/storages/backends/s3boto.py#L24-L27



# What's it you're proposing?

Install `boto` in addition to `boto3`.

