### PR TITLE
Add django and postgres envs to celeryworker and celerybeat

### DIFF
--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -51,11 +51,16 @@ services:
     <<: *django
     image: {{ cookiecutter.project_slug }}_production_celeryworker
     command: /start-celeryworker
+    env_file:
+      - ./.envs/.production/.django
+      - ./.envs/.production/.postgres
 
   celerybeat:
     <<: *django
     image: {{ cookiecutter.project_slug }}_production_celerybeat
     command: /start-celerybeat
+    env_file:
+      - ./.envs/.production/.postgres
 
   flower:
     <<: *django


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

It took me a while to get my celery worker and celery beat docker images working on the production environment. The error messages are similar to

```
Message Error: cannot add item to database

celerybeat raised exception <class 'dbm.error'>: error('cannot add item to database',)
```

and it turned out that the celery worker could not connect to `S3` and database because of missing `AWS` and postgres environment variables, and `celerybeat` could not connect to the database because of missing postgres environment variables.

# What's it you're proposing?

Adding 

```
+    env_file:
+      - ./.envs/.production/.django
+      - ./.envs/.production/.postgres
```
to `celery` etc in `production.yml`.

Note that it is possible that users' celery worker does not talk to S3 or the database, but I do not see any harm making the variables available to the worker.