### PR TITLE
Update django-storages to 1.9

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -16,6 +16,6 @@ sentry-sdk==0.14.1  # https://github.com/getsentry/sentry-python
 {%- if cookiecutter.cloud_provider == 'AWS' %}
 django-storages[boto3]==1.9  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
-django-storages[google]==1.8  # https://github.com/jschneier/django-storages
+django-storages[google]==1.9  # https://github.com/jschneier/django-storages
 {%- endif %}
 django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -14,7 +14,7 @@ sentry-sdk==0.14.1  # https://github.com/getsentry/sentry-python
 # Django
 # ------------------------------------------------------------------------------
 {%- if cookiecutter.cloud_provider == 'AWS' %}
-django-storages[boto3]==1.8  # https://github.com/jschneier/django-storages
+django-storages[boto3]==1.9  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
 django-storages[google]==1.8  # https://github.com/jschneier/django-storages
 {%- endif %}


### PR DESCRIPTION

This PR updates [django-storages[boto3]](https://pypi.org/project/django-storages) from **1.8** to **1.9**.





---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
