### PR TITLE
Add all supported Anymail Providers

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -56,6 +56,7 @@ Listed in alphabetical order.
   Andreas Meistad          `@ameistad`_
   Andres Gonzalez          `@andresgz`_
   Andrew Mikhnevich        `@zcho`_
+  Andrew Chen Wang         `@Andrew-Chen-Wang`_
   Andy Rose
   Anna Callahan            `@jazztpt`_
   Anna Sidwell             `@takkaria`_
@@ -228,6 +229,7 @@ Listed in alphabetical order.
 .. _@andor-pierdelacabeza: https://github.com/andor-pierdelacabeza
 .. _@andresgz: https://github.com/andresgz
 .. _@antoniablair: https://github.com/antoniablair
+.. _@Andrew-Chen-Wang: https://github.com/Andrew-Chen-Wang
 .. _@apirobot: https://github.com/apirobot
 .. _@archinal: https://github.com/archinal
 .. _@areski: https://github.com/areski

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Features
 * Registration via django-allauth_
 * Comes with custom user model ready to go
 * Optional custom static build using Gulp and livereload
-* Send emails via Anymail_ (using Mailgun_ by default, but switchable)
+* Send emails via Anymail_ (using Mailgun_ by default or Amazon SES if AWS is selected cloud provider, but switchable)
 * Media storage using Amazon S3 or Google Cloud Storage
 * Docker support using docker-compose_ for development and production (using Traefik_ with LetsEncrypt_ support)
 * Procfile_ for deploying to Heroku
@@ -85,7 +85,7 @@ Optional Integrations
 .. _PythonAnywhere: https://www.pythonanywhere.com/
 .. _Traefik: https://traefik.io/
 .. _LetsEncrypt: https://letsencrypt.org/
-.. _pre-commit: https://github.com/pre-commit/pre-commit 
+.. _pre-commit: https://github.com/pre-commit/pre-commit
 
 Constraints
 -----------

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -34,7 +34,7 @@
     "None"
   ],
   "mail_service": [
-    {% if cookiecutter.cloud_provider == 'AWS' %}"Amazon SES",{% endif %}
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Amazon SES{% else %}None{% endif %}",
     "Mailgun",
     "Mailjet",
     "Mandrill",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -34,16 +34,16 @@
     "None"
   ],
   "mail_service": [
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Amazon SES{% else %}Mailgun{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Mailgun{% else %}Mailjet{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Mailjet{% else %}Mandrill{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Mandrill{% else %}Postmark{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Postmark{% else %}Sendgrid{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Sendgrid{% else %}SendinBlue{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}SendinBlue{% else %}SparkPost{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}SparkPost{% else %}Plain Django-Anymail{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Plain Django-Anymail{% else %}None{% endif %}",
-    "{% if cookiecutter.cloud_provider == 'AWS' %}None{% else %}None{% endif %}"
+    {% if cookiecutter.cloud_provider == 'AWS' %}"Amazon SES",{% endif %}
+    "Mailgun",
+    "Mailjet",
+    "Mandrill",
+    "Postmark",
+    "Sendgrid",
+    "SendinBlue",
+    "SparkPost",
+    "Plain/Vanilla Django-Anymail",
+    "None"
   ],
   "use_drf": "n",
   "custom_bootstrap_compilation": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -34,7 +34,7 @@
     "None"
   ],
   "mail_service": [
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Amazon SES{% else %}None{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Amazon SES{% else %}Plain/Vanilla Django-Anymail{% endif %}",
     "Mailgun",
     "Mailjet",
     "Mandrill",
@@ -42,8 +42,7 @@
     "Sendgrid",
     "SendinBlue",
     "SparkPost",
-    "Plain/Vanilla Django-Anymail",
-    "None"
+    "Plain/Vanilla Django-Anymail"
   ],
   "use_drf": "n",
   "custom_bootstrap_compilation": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -33,6 +33,18 @@
     "GCP",
     "None"
   ],
+  "mail_service": [
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Amazon SES{% else %}Mailgun{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Mailgun{% else %}Mailjet{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Mailjet{% else %}Mandrill{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Mandrill{% else %}Postmark{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Postmark{% else %}Sendgrid{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Sendgrid{% else %}SendinBlue{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}SendinBlue{% else %}SparkPost{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}SparkPost{% else %}Plain Django-Anymail{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}Plain Django-Anymail{% else %}None{% endif %}",
+    "{% if cookiecutter.cloud_provider == 'AWS' %}None{% else %}None{% endif %}"
+  ],
   "use_drf": "n",
   "custom_bootstrap_compilation": "n",
   "use_compressor": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -34,15 +34,15 @@
     "None"
   ],
   "mail_service": [
-    "{% if cookiecutter.cloud_provider == 'AWS' %}Amazon SES{% else %}Plain/Vanilla Django-Anymail{% endif %}",
     "Mailgun",
+    "Amazon SES",
     "Mailjet",
     "Mandrill",
     "Postmark",
     "Sendgrid",
     "SendinBlue",
     "SparkPost",
-    "Plain/Vanilla Django-Anymail"
+    "Other SMTP"
   ],
   "use_drf": "n",
   "custom_bootstrap_compilation": "n",

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -70,6 +70,19 @@ cloud_provider:
 
     Note that if you choose no cloud provider, media files won't work.
 
+mail_service:
+    Select an email service that Django-Anymail provides
+
+    1. Amazon SES_
+    2. Mailgun_
+    3. Mailjet_
+    4. Mandrill_
+    5. Postmark_
+    6. SendGrid_
+    7. SendinBlue_
+    8. SparkPost_
+    9. Plain/Vanilla Django-Anymail_
+
 use_drf:
     Indicates whether the project should be configured to use `Django Rest Framework`_.
 
@@ -131,6 +144,16 @@ debug:
 
 .. _AWS: https://aws.amazon.com/s3/
 .. _GCP: https://cloud.google.com/storage/
+
+.. _SES: https://aws.amazon.com/ses/
+.. _Mailgun: https://www.mailgun.com
+.. _Mailjet: https://www.mailjet.com
+.. _Mandrill: http://mandrill.com
+.. _Postmark: https://postmarkapp.com
+.. _SendGrid: https://sendgrid.com
+.. _SendinBlue: https://www.sendinblue.com
+.. _SparkPost: https://www.sparkpost.com
+.. _Django-Anymail: https://anymail.readthedocs.io/en/stable/
 
 .. _Django Rest Framework: https://github.com/encode/django-rest-framework/
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -52,6 +52,21 @@ DJANGO_SENTRY_LOG_LEVEL                 SENTRY_LOG_LEVEL            n/a         
 MAILGUN_API_KEY                         MAILGUN_API_KEY             n/a                                            raises error
 MAILGUN_DOMAIN                          MAILGUN_SENDER_DOMAIN       n/a                                            raises error
 MAILGUN_API_URL                         n/a                         n/a                                            "https://api.mailgun.net/v3"
+MAILJET_API_KEY                         MAILJET_API_KEY             n/a                                            raises error
+MAILJET_SECRET_KEY                      MAILJET_SECRET_KEY          n/a                                            raises error
+MAILJET_API_URL                         n/a                         n/a                                            "https://api.mailjet.com/v3"
+MANDRILL_API_KEY                        MANDRILL_API_KEY            n/a                                            raises error
+MANDRILL_API_URL                        n/a                         n/a                                            "https://mandrillapp.com/api/1.0"
+POSTMARK_SERVER_TOKEN                   POSTMARK_SERVER_TOKEN       n/a                                            raises error
+POSTMARK_API_URL                        n/a                         n/a                                            "https://api.postmarkapp.com/"
+SENDGRID_API_KEY                        SENDGRID_API_KEY            n/a                                            raises error
+SENDGRID_GENERATE_MESSAGE_ID            True                        n/a                                            raises error
+SENDGRID_MERGE_FIELD_FORMAT             None                        n/a                                            raises error
+SENDGRID_API_URL                        n/a                         n/a                                            "https://api.sendgrid.com/v3/"
+SENDINBLUE_API_KEY                      SENDINBLUE_API_KEY          n/a                                            raises error
+SENDINBLUE_API_URL                      n/a                         n/a                                            "https://api.sendinblue.com/v3/"
+SPARKPOST_API_KEY                       SPARKPOST_API_KEY           n/a                                            raises error
+SPARKPOST_API_URL                       n/a                         n/a                                            "https://api.sparkpost.com/api/v1"
 ======================================= =========================== ============================================== ======================================================================
 
 --------------------------

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -48,6 +48,15 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "GCP", "use_whitenoise": "n"},
     {"cloud_provider": "None", "use_whitenoise": "y"},
     # Note: cloud_provider=None AND use_whitenoise=n is not supported
+    {"mail_service": "Mailgun"},
+    {"mail_service": "Amazon SES"},
+    {"mail_service": "Mailjet"},
+    {"mail_service": "Mandrill"},
+    {"mail_service": "Postmark"},
+    {"mail_service": "Sendgrid"},
+    {"mail_service": "SendinBlue"},
+    {"mail_service": "SparkPost"},
+    {"mail_service": "Other SMTP"},
     {"use_drf": "y"},
     {"use_drf": "n"},
     {"js_task_runner": "None"},
@@ -73,21 +82,10 @@ SUPPORTED_COMBINATIONS = [
     {"keep_local_envs_in_vcs": "n"},
     {"debug": "y"},
     {"debug": "n"},
-    {"mail_service", "AWS SES"},
-    {"mail_service", "Mailgun"},
-    {"mail_service", "Mailjet"},
-    {"mail_service", "Mandrill"},
-    {"mail_service", "Postmark"},
-    {"mail_service", "Sendgrid"},
-    {"mail_service", "SendinBlue"},
-    {"mail_service", "SparkPost"},
-    {"mail_service", "Other SMTP"},
 ]
 
 UNSUPPORTED_COMBINATIONS = [
     {"cloud_provider": "None", "use_whitenoise": "n"},
-    {"cloud_provider": "GCP", "mail_service": "Amazon SES"},
-    {"cloud_provider": "None", "mail_service": "Amazon SES"}
 ]
 
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -47,39 +47,20 @@ def context():
     ids=lambda id: f"wnoise:{id[0]}-cloud:{id[1]}",
 )
 @pytest.mark.parametrize(
-    "cloud_provider,mail_service",
+    "mail_service",
     [
-        ("AWS", "Amazon SES"),
-        ("AWS", "Mailgun"),
-        ("AWS", "Mailjet"),
-        ("AWS", "Mandrill"),
-        ("AWS", "Postmark"),
-        ("AWS", "Sendgrid"),
-        ("AWS", "SendinBlue"),
-        ("AWS", "SparkPost"),
-        ("AWS", "Plain/Vanilla Django-Anymail"),
-
-        ("GCP", "Mailgun"),
-        ("GCP", "Mailjet"),
-        ("GCP", "Mandrill"),
-        ("GCP", "Postmark"),
-        ("GCP", "Sendgrid"),
-        ("GCP", "SendinBlue"),
-        ("GCP", "SparkPost"),
-        ("GCP", "Plain/Vanilla Django-Anymail"),
-
-        ("None", "Mailgun"),
-        ("None", "Mailjet"),
-        ("None", "Mandrill"),
-        ("None", "Postmark"),
-        ("None", "Sendgrid"),
-        ("None", "SendinBlue"),
-        ("None", "SparkPost"),
-        ("None", "Plain/Vanilla Django-Anymail"),
-
+        "Amazon SES",
+        "Mailgun",
+        "MailJet",
+        "Mandrill",
+        "Postmark",
+        "Sendgrid",
+        "SendinBlue",
+        "SparkPost",
+        "Plain/Vanilla Django-Anymail"
         # GCP or None (i.e. no cloud provider) + Amazon SES is not supported
     ],
-    ids=lambda id: f"cloud:{id[0]}-mail:{id[1]}",
+    ids=lambda id: f"mail:{id[0]}",
 )
 def context_combination(
     windows,

--- a/{{cookiecutter.project_slug}}/.envs/.production/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.production/.django
@@ -13,9 +13,26 @@ DJANGO_SECURE_SSL_REDIRECT=False
 
 # Email
 # ------------------------------------------------------------------------------
-MAILGUN_API_KEY=
 DJANGO_SERVER_EMAIL=
+{% if cookiecutter.mail_service == 'Mailgun' %}
+MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
+{% elif cookiecutter.mail_service == 'Mailjet' %}
+MAILJET_API_KEY=
+MAILJET_SECRET_KEY=
+{% elif cookiecutter.mail_service == 'Mandrill' %}
+MANDRILL_API_KEY=
+{% elif cookiecutter.mail_service == 'Postmark' %}
+POSTMARK_SERVER_TOKEN=
+{% elif cookiecutter.mail_service == 'Sendgrid' %}
+SENDGRID_API_KEY=
+SENDGRID_GENERATE_MESSAGE_ID=True
+SENDGRID_MERGE_FIELD_FORMAT=None
+{% elif cookiecutter.mail_service == 'SendinBlue' %}
+SENDINBLUE_API_KEY=
+{% elif cookiecutter.mail_service == 'SparkPost' %}
+SPARKPOST_API_KEY=
+{% endif %}
 {% if cookiecutter.cloud_provider == 'AWS' %}
 # AWS
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -208,39 +208,61 @@ EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 {%- endif %}
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {
+    # https://anymail.readthedocs.io/en/stable/esps/
     {%- if cookiecutter.mail_service == 'Amazon SES' %}
     # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
     {%- elif cookiecutter.mail_service == 'Mailgun' %}
     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
-    "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
+    "MAILGUN_API_URL": env(
+        "MAILGUN_API_URL",
+        default="https://api.mailgun.net/v3"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/mailgun/
     {%- elif cookiecutter.mail_service == 'Mailjet' %}
     "MAILJET_API_KEY": env("MAILJET_API_KEY"),
     "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
-    "MAILJET_API_URL": env("MAILJET_API_URL", default="https://api.mailjet.com/v3"),
+    "MAILJET_API_URL": env(
+        "MAILJET_API_URL",
+        default="https://api.mailjet.com/v3"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/mailjet/
     {%- elif cookiecutter.mail_service == 'Mandrill' %}
     "MANDRILL_API_KEY": env("MANDRILL_API_KEY"),
-    "MANDRILL_API_URL": env("MANDRILL_API_URL", default="https://mandrillapp.com/api/1.0"),
+    "MANDRILL_API_URL": env(
+        "MANDRILL_API_URL",
+        default="https://mandrillapp.com/api/1.0"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/mandrill/
     {%- elif cookiecutter.mail_service == 'Postmark' %}
     "POSTMARK_SERVER_TOKEN": env("POSTMARK_SERVER_TOKEN"),
-    "POSTMARK_API_URL": env("POSTMARK_API_URL", default="https://api.postmarkapp.com/"),
+    "POSTMARK_API_URL": env(
+        "POSTMARK_API_URL",
+        default="https://api.postmarkapp.com/"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/postmark/
     {%- elif cookiecutter.mail_service == 'Sendgrid' %}
     "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
     "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
     "SENDGRID_MERGE_FIELD_FORMAT": env("SENDGRID_MERGE_FIELD_FORMAT"),
-    "SENDGRID_API_URL": env("SENDGRID_API_URL", default="https://api.sendgrid.com/v3/"),
+    "SENDGRID_API_URL": env(
+        "SENDGRID_API_URL",
+        default="https://api.sendgrid.com/v3/"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/sendgrid/
     {%- elif cookiecutter.mail_service == 'SendinBlue' %}
     "SENDINBLUE_API_KEY": env("SENDINBLUE_API_KEY"),
-    "SENDINBLUE_API_URL": env("SENDINBLUE_API_URL", default="https://api.sendinblue.com/v3/"),
+    "SENDINBLUE_API_URL": env(
+        "SENDINBLUE_API_URL",
+        default="https://api.sendinblue.com/v3/"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/sendinblue/
     {%- elif cookiecutter.mail_service == 'SparkPost' %}
     "SPARKPOST_API_KEY": env("SPARKPOST_API_KEY"),
-    "SPARKPOST_API_URL": env("SPARKPOST_API_URL", default="https://api.sparkpost.com/api/v1"),
+    "SPARKPOST_API_URL": env(
+        "SPARKPOST_API_URL",
+        default="https://api.sparkpost.com/api/v1"
+    ),
     # https://anymail.readthedocs.io/en/stable/esps/sparkpost/
     {%- endif %}
 }

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -187,62 +187,58 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]  # noqa F405
-{%- if cookiecutter.mail_service == 'Amazon SES' %}
-EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
-{%- elif cookiecutter.mail_service == 'Mailgun' %}
-EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
-{%- elif cookiecutter.mail_service == 'Mailjet' %}
-EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
-{%- elif cookiecutter.mail_service == 'Mandrill' %}
-EMAIL_BACKEND = "anymail.backends.mandrill.EmailBackend"
-{%- elif cookiecutter.mail_service == 'Postmark' %}
-EMAIL_BACKEND = "anymail.backends.postmark.EmailBackend"
-{%- elif cookiecutter.mail_service == 'Sendgrid' %}
-EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
-{%- elif cookiecutter.mail_service == 'SendinBlue' %}
-EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
-{%- elif cookiecutter.mail_service == 'SparkPost' %}
-EMAIL_BACKEND = "anymail.backends.sparkpost.EmailBackend"
-{%- elif cookiecutter.mail_service == 'Plain/Vanilla Django-Anymail' %}
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-# https://docs.djangoproject.com/en/3.0/ref/settings/#email-backend
-{%- endif %}
+# https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
+{%- if cookiecutter.mail_service == 'Mailgun' %}
+# https://anymail.readthedocs.io/en/stable/esps/mailgun/
+EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 ANYMAIL = {
-    # https://anymail.readthedocs.io/en/stable/esps/
-    {%- if cookiecutter.mail_service == 'Amazon SES' %}
-    # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
-    {%- elif cookiecutter.mail_service == 'Mailgun' %}
     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
     "MAILGUN_API_URL": env(
         "MAILGUN_API_URL",
         default="https://api.mailgun.net/v3"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/mailgun/
-    {%- elif cookiecutter.mail_service == 'Mailjet' %}
+}
+{%- elif cookiecutter.mail_service == 'Amazon SES' %}
+# https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
+EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
+ANYMAIL = {}
+{%- elif cookiecutter.mail_service == 'Mailjet' %}
+# https://anymail.readthedocs.io/en/stable/esps/mailjet/
+EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
+ANYMAIL = {
     "MAILJET_API_KEY": env("MAILJET_API_KEY"),
     "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
     "MAILJET_API_URL": env(
         "MAILJET_API_URL",
         default="https://api.mailjet.com/v3"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/mailjet/
-    {%- elif cookiecutter.mail_service == 'Mandrill' %}
+}
+{%- elif cookiecutter.mail_service == 'Mandrill' %}
+# https://anymail.readthedocs.io/en/stable/esps/mandrill/
+EMAIL_BACKEND = "anymail.backends.mandrill.EmailBackend"
+ANYMAIL = {
     "MANDRILL_API_KEY": env("MANDRILL_API_KEY"),
     "MANDRILL_API_URL": env(
         "MANDRILL_API_URL",
         default="https://mandrillapp.com/api/1.0"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/mandrill/
-    {%- elif cookiecutter.mail_service == 'Postmark' %}
+}
+{%- elif cookiecutter.mail_service == 'Postmark' %}
+# https://anymail.readthedocs.io/en/stable/esps/postmark/
+EMAIL_BACKEND = "anymail.backends.postmark.EmailBackend"
+ANYMAIL = {
     "POSTMARK_SERVER_TOKEN": env("POSTMARK_SERVER_TOKEN"),
     "POSTMARK_API_URL": env(
         "POSTMARK_API_URL",
         default="https://api.postmarkapp.com/"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/postmark/
-    {%- elif cookiecutter.mail_service == 'Sendgrid' %}
+}
+{%- elif cookiecutter.mail_service == 'Sendgrid' %}
+# https://anymail.readthedocs.io/en/stable/esps/sendgrid/
+EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
+ANYMAIL = {
     "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
     "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
     "SENDGRID_MERGE_FIELD_FORMAT": env("SENDGRID_MERGE_FIELD_FORMAT"),
@@ -250,23 +246,32 @@ ANYMAIL = {
         "SENDGRID_API_URL",
         default="https://api.sendgrid.com/v3/"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/sendgrid/
-    {%- elif cookiecutter.mail_service == 'SendinBlue' %}
+}
+{%- elif cookiecutter.mail_service == 'SendinBlue' %}
+# https://anymail.readthedocs.io/en/stable/esps/sendinblue/
+EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
+ANYMAIL = {
     "SENDINBLUE_API_KEY": env("SENDINBLUE_API_KEY"),
     "SENDINBLUE_API_URL": env(
         "SENDINBLUE_API_URL",
         default="https://api.sendinblue.com/v3/"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/sendinblue/
-    {%- elif cookiecutter.mail_service == 'SparkPost' %}
+}
+{%- elif cookiecutter.mail_service == 'SparkPost' %}
+# https://anymail.readthedocs.io/en/stable/esps/sparkpost/
+EMAIL_BACKEND = "anymail.backends.sparkpost.EmailBackend"
+ANYMAIL = {
     "SPARKPOST_API_KEY": env("SPARKPOST_API_KEY"),
     "SPARKPOST_API_URL": env(
         "SPARKPOST_API_URL",
         default="https://api.sparkpost.com/api/v1"
     ),
-    # https://anymail.readthedocs.io/en/stable/esps/sparkpost/
-    {%- endif %}
 }
+{%- elif cookiecutter.mail_service == 'Other SMTP' %}
+# https://anymail.readthedocs.io/en/stable/esps
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+ANYMAIL = {}
+{%- endif %}
 
 {% if cookiecutter.use_compressor == 'y' -%}
 # django-compressor

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -182,16 +182,66 @@ EMAIL_SUBJECT_PREFIX = env(
 # Django Admin URL regex.
 ADMIN_URL = env("DJANGO_ADMIN_URL")
 
-# Anymail (Mailgun)
+# Anymail
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]  # noqa F405
+{%- if cookiecutter.mail_service == 'Amazon SES' %}
+EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
+{%- elif cookiecutter.mail_service == 'Mailgun' %}
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/mailgun/
+{%- elif cookiecutter.mail_service == 'Mailjet' %}
+EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/mailjet/
+{%- elif cookiecutter.mail_service == 'Mandrill' %}
+EMAIL_BACKEND = "anymail.backends.mandrill.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/mandrill/
+{%- elif cookiecutter.mail_service == 'Postmark' %}
+EMAIL_BACKEND = "anymail.backends.postmark.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/postmark/
+{%- elif cookiecutter.mail_service == 'Sendgrid' %}
+EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/sendgrid/
+{%- elif cookiecutter.mail_service == 'SendinBlue' %}
+EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/sendinblue/
+{%- elif cookiecutter.mail_service == 'SparkPost' %}
+EMAIL_BACKEND = "anymail.backends.sparkpost.EmailBackend"
+# https://anymail.readthedocs.io/en/stable/esps/sparkpost/
+{%- elif cookiecutter.mail_service == 'Plain/Vanilla Django-Anymail' %}
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+# https://docs.djangoproject.com/en/3.0/ref/settings/#email-backend
+{%- endif %}
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {
+    {%- if cookiecutter.mail_service == 'Mailgun' %}
     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
     "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
+    {%- elif cookiecutter.mail_service == 'Mailjet' %}
+    "MAILJET_API_KEY": env("MAILJET_API_KEY"),
+    "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
+    "MAILJET_API_URL": env("MAILJET_API_URL", default="https://api.mailjet.com/v3"),
+    {%- elif cookiecutter.mail_service == 'Mandrill' %}
+    "MANDRILL_API_KEY": env("MANDRILL_API_KEY"),
+    "MANDRILL_API_URL": env("MANDRILL_API_URL", default="https://mandrillapp.com/api/1.0"),
+    {%- elif cookiecutter.mail_service == 'Postmark' %}
+    "POSTMARK_SERVER_TOKEN": env("POSTMARK_SERVER_TOKEN"),
+    "POSTMARK_API_URL": env("POSTMARK_API_URL", default="https://api.postmarkapp.com/"),
+    {%- elif cookiecutter.mail_service == 'Sendgrid' %}
+    "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
+    "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
+    "SENDGRID_MERGE_FIELD_FORMAT": env("SENDGRID_MERGE_FIELD_FORMAT"),
+    "SENDGRID_API_URL": env("SENDGRID_API_URL", default="https://api.sendgrid.com/v3/"),
+    {%- elif cookiecutter.mail_service == 'SendinBlue' %}
+    "SENDINBLUE_API_KEY": env("SENDINBLUE_API_KEY"),
+    "SENDINBLUE_API_URL": env("SENDINBLUE_API_URL", default="https://api.sendinblue.com/v3/"),
+    {%- elif cookiecutter.mail_service == 'SparkPost' %}
+    "SPARKPOST_API_KEY": env("SPARKPOST_API_KEY"),
+    "SPARKPOST_API_URL": env("SPARKPOST_API_URL", default="https://api.sparkpost.com/api/v1"),
+    {%- endif %}
 }
 
 {% if cookiecutter.use_compressor == 'y' -%}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -195,10 +195,7 @@ EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 ANYMAIL = {
     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
-    "MAILGUN_API_URL": env(
-        "MAILGUN_API_URL",
-        default="https://api.mailgun.net/v3"
-    ),
+    "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
 }
 {%- elif cookiecutter.mail_service == 'Amazon SES' %}
 # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
@@ -210,10 +207,7 @@ EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 ANYMAIL = {
     "MAILJET_API_KEY": env("MAILJET_API_KEY"),
     "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
-    "MAILJET_API_URL": env(
-        "MAILJET_API_URL",
-        default="https://api.mailjet.com/v3"
-    ),
+    "MAILJET_API_URL": env("MAILJET_API_URL", default="https://api.mailjet.com/v3"),
 }
 {%- elif cookiecutter.mail_service == 'Mandrill' %}
 # https://anymail.readthedocs.io/en/stable/esps/mandrill/
@@ -221,8 +215,7 @@ EMAIL_BACKEND = "anymail.backends.mandrill.EmailBackend"
 ANYMAIL = {
     "MANDRILL_API_KEY": env("MANDRILL_API_KEY"),
     "MANDRILL_API_URL": env(
-        "MANDRILL_API_URL",
-        default="https://mandrillapp.com/api/1.0"
+        "MANDRILL_API_URL", default="https://mandrillapp.com/api/1.0"
     ),
 }
 {%- elif cookiecutter.mail_service == 'Postmark' %}
@@ -230,10 +223,7 @@ ANYMAIL = {
 EMAIL_BACKEND = "anymail.backends.postmark.EmailBackend"
 ANYMAIL = {
     "POSTMARK_SERVER_TOKEN": env("POSTMARK_SERVER_TOKEN"),
-    "POSTMARK_API_URL": env(
-        "POSTMARK_API_URL",
-        default="https://api.postmarkapp.com/"
-    ),
+    "POSTMARK_API_URL": env("POSTMARK_API_URL", default="https://api.postmarkapp.com/"),
 }
 {%- elif cookiecutter.mail_service == 'Sendgrid' %}
 # https://anymail.readthedocs.io/en/stable/esps/sendgrid/
@@ -242,10 +232,7 @@ ANYMAIL = {
     "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
     "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
     "SENDGRID_MERGE_FIELD_FORMAT": env("SENDGRID_MERGE_FIELD_FORMAT"),
-    "SENDGRID_API_URL": env(
-        "SENDGRID_API_URL",
-        default="https://api.sendgrid.com/v3/"
-    ),
+    "SENDGRID_API_URL": env("SENDGRID_API_URL", default="https://api.sendgrid.com/v3/"),
 }
 {%- elif cookiecutter.mail_service == 'SendinBlue' %}
 # https://anymail.readthedocs.io/en/stable/esps/sendinblue/
@@ -253,8 +240,7 @@ EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
 ANYMAIL = {
     "SENDINBLUE_API_KEY": env("SENDINBLUE_API_KEY"),
     "SENDINBLUE_API_URL": env(
-        "SENDINBLUE_API_URL",
-        default="https://api.sendinblue.com/v3/"
+        "SENDINBLUE_API_URL", default="https://api.sendinblue.com/v3/"
     ),
 }
 {%- elif cookiecutter.mail_service == 'SparkPost' %}
@@ -263,8 +249,7 @@ EMAIL_BACKEND = "anymail.backends.sparkpost.EmailBackend"
 ANYMAIL = {
     "SPARKPOST_API_KEY": env("SPARKPOST_API_KEY"),
     "SPARKPOST_API_URL": env(
-        "SPARKPOST_API_URL",
-        default="https://api.sparkpost.com/api/v1"
+        "SPARKPOST_API_URL", default="https://api.sparkpost.com/api/v1"
     ),
 }
 {%- elif cookiecutter.mail_service == 'Other SMTP' %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -188,59 +188,60 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 INSTALLED_APPS += ["anymail"]  # noqa F405
 {%- if cookiecutter.mail_service == 'Amazon SES' %}
 EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
 {%- elif cookiecutter.mail_service == 'Mailgun' %}
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/mailgun/
 {%- elif cookiecutter.mail_service == 'Mailjet' %}
 EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/mailjet/
 {%- elif cookiecutter.mail_service == 'Mandrill' %}
 EMAIL_BACKEND = "anymail.backends.mandrill.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/mandrill/
 {%- elif cookiecutter.mail_service == 'Postmark' %}
 EMAIL_BACKEND = "anymail.backends.postmark.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/postmark/
 {%- elif cookiecutter.mail_service == 'Sendgrid' %}
 EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/sendgrid/
 {%- elif cookiecutter.mail_service == 'SendinBlue' %}
 EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/sendinblue/
 {%- elif cookiecutter.mail_service == 'SparkPost' %}
 EMAIL_BACKEND = "anymail.backends.sparkpost.EmailBackend"
-# https://anymail.readthedocs.io/en/stable/esps/sparkpost/
 {%- elif cookiecutter.mail_service == 'Plain/Vanilla Django-Anymail' %}
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 # https://docs.djangoproject.com/en/3.0/ref/settings/#email-backend
 {%- endif %}
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {
-    {%- if cookiecutter.mail_service == 'Mailgun' %}
+    {%- if cookiecutter.mail_service == 'Amazon SES' %}
+    # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
+    {%- elif cookiecutter.mail_service == 'Mailgun' %}
     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
     "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
+    # https://anymail.readthedocs.io/en/stable/esps/mailgun/
     {%- elif cookiecutter.mail_service == 'Mailjet' %}
     "MAILJET_API_KEY": env("MAILJET_API_KEY"),
     "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
     "MAILJET_API_URL": env("MAILJET_API_URL", default="https://api.mailjet.com/v3"),
+    # https://anymail.readthedocs.io/en/stable/esps/mailjet/
     {%- elif cookiecutter.mail_service == 'Mandrill' %}
     "MANDRILL_API_KEY": env("MANDRILL_API_KEY"),
     "MANDRILL_API_URL": env("MANDRILL_API_URL", default="https://mandrillapp.com/api/1.0"),
+    # https://anymail.readthedocs.io/en/stable/esps/mandrill/
     {%- elif cookiecutter.mail_service == 'Postmark' %}
     "POSTMARK_SERVER_TOKEN": env("POSTMARK_SERVER_TOKEN"),
     "POSTMARK_API_URL": env("POSTMARK_API_URL", default="https://api.postmarkapp.com/"),
+    # https://anymail.readthedocs.io/en/stable/esps/postmark/
     {%- elif cookiecutter.mail_service == 'Sendgrid' %}
     "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
     "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
     "SENDGRID_MERGE_FIELD_FORMAT": env("SENDGRID_MERGE_FIELD_FORMAT"),
     "SENDGRID_API_URL": env("SENDGRID_API_URL", default="https://api.sendgrid.com/v3/"),
+    # https://anymail.readthedocs.io/en/stable/esps/sendgrid/
     {%- elif cookiecutter.mail_service == 'SendinBlue' %}
     "SENDINBLUE_API_KEY": env("SENDINBLUE_API_KEY"),
     "SENDINBLUE_API_URL": env("SENDINBLUE_API_URL", default="https://api.sendinblue.com/v3/"),
+    # https://anymail.readthedocs.io/en/stable/esps/sendinblue/
     {%- elif cookiecutter.mail_service == 'SparkPost' %}
     "SPARKPOST_API_KEY": env("SPARKPOST_API_KEY"),
     "SPARKPOST_API_URL": env("SPARKPOST_API_URL", default="https://api.sparkpost.com/api/v1"),
+    # https://anymail.readthedocs.io/en/stable/esps/sparkpost/
     {%- endif %}
 }
 

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -18,10 +18,10 @@ django-storages[boto3]==1.9.1  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
 django-storages[google]==1.9.1  # https://github.com/jschneier/django-storages
 {%- endif %}
-{%- if cookiecutter.mail_service == 'Amazon SES' %}
-django-anymail[amazon_ses]==7.0.0  # https://github.com/anymail/django-anymail
-{%- elif cookiecutter.mail_service == 'Mailgun' %}
+{%- if cookiecutter.mail_service == 'Mailgun' %}
 django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Amazon SES' %}
+django-anymail[amazon_ses]==7.0.0  # https://github.com/anymail/django-anymail
 {%- elif cookiecutter.mail_service == 'Mailjet' %}
 django-anymail[mailjet]==7.0.0  # https://github.com/anymail/django-anymail
 {%- elif cookiecutter.mail_service == 'Mandrill' %}
@@ -34,6 +34,6 @@ django-anymail[sendgrid]==7.0.0  # https://github.com/anymail/django-anymail
 django-anymail[sendinblue]==7.0.0  # https://github.com/anymail/django-anymail
 {%- elif cookiecutter.mail_service == 'SparkPost' %}
 django-anymail[sparkpost]==7.0.0  # https://github.com/anymail/django-anymail
-{%- elif cookiecutter.mail_service == 'Plain/Vanilla Django-Anymail' %}
+{%- elif cookiecutter.mail_service == 'Other SMTP' %}
 django-anymail==7.0.0  # https://github.com/anymail/django-anymail
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -18,4 +18,22 @@ django-storages[boto3]==1.9.1  # https://github.com/jschneier/django-storages
 {%- elif cookiecutter.cloud_provider == 'GCP' %}
 django-storages[google]==1.9.1  # https://github.com/jschneier/django-storages
 {%- endif %}
+{%- if cookiecutter.mail_service == 'Amazon SES' %}
+django-anymail[amazon_ses]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Mailgun' %}
 django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Mailjet' %}
+django-anymail[mailjet]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Mandrill' %}
+django-anymail[mandrill]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Postmark' %}
+django-anymail[postmark]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Sendgrid' %}
+django-anymail[sendgrid]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'SendinBlue' %}
+django-anymail[sendinblue]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'SparkPost' %}
+django-anymail[sparkpost]==7.0.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'Plain/Vanilla Django-Anymail' %}
+django-anymail==7.0.0  # https://github.com/anymail/django-anymail
+{%- endif %}


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Providing options for all Anymail-supported ESP:
SES, Mailgun, Mailjet, Mandrill, Postmark, Sendgrid, SendinBlue, SparkPost, Plain/Vanilla Django-anymail, None.


## Rationale

[//]: # (Why does the project need that?)

The default is Mailgun. Financially, it **_could_** be more wise to use SES if the cloud provider is AWS. Some people prefer other options, too.

Alleviates setup for users choosing option other than mailgun.

Fixes #2140 


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

Selecting an email provider from the beginning alleviates setup later on.
