### PR TITLE
Fix broken Django Compressor setup and enable static files minification

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -299,6 +299,7 @@ Listed in alphabetical order.
 .. _@howiezhao: https://github.com/howiezhao
 .. _@IanLee1521: https://github.com/IanLee1521
 .. _@ikhomutov: https://github.com/ikhomutov
+.. _@jameswilliams1: https://github.com/jameswilliams1
 .. _@ikkebr: https://github.com/ikkebr
 .. _@Isaac12x: https://github.com/Isaac12x
 .. _@iynaix: https://github.com/iynaix

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -129,6 +129,7 @@ Listed in alphabetical order.
   Irfan Ahmad              `@erfaan`_                    @erfaan
   Isaac12x                 `@Isaac12x`_
   Ivan Khomutov            `@ikhomutov`_
+  James Williams           `@jameswilliams1`_
   Jan Van Bruggen          `@jvanbrug`_
   Jelmer Draaijer          `@foarsitter`_
   Jerome Caisip            `@jeromecaisip`_

--- a/{{cookiecutter.project_slug}}/.envs/.production/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.production/.django
@@ -31,11 +31,7 @@ DJANGO_GCP_STORAGE_BUCKET_NAME=
 # django-allauth
 # ------------------------------------------------------------------------------
 DJANGO_ACCOUNT_ALLOW_REGISTRATION=True
-{% if cookiecutter.use_compressor == 'y' %}
-# django-compressor
-# ------------------------------------------------------------------------------
-COMPRESS_ENABLED=
-{% endif %}
+
 # Gunicorn
 # ------------------------------------------------------------------------------
 WEB_CONCURRENCY=4

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -6,9 +6,24 @@ set -o nounset
 
 
 python /app/manage.py collectstatic --noinput
-{%- if cookiecutter.use_whitenoise == 'y' and cookiecutter.use_compressor == 'y' %}
-if [ "${COMPRESS_ENABLED:-}" = "True" ];
-then
+{% if cookiecutter.use_whitenoise == 'y' and cookiecutter.use_compressor == 'y' %}
+compress_enabled() {
+python << END
+import sys
+
+from environ import Env
+
+env = Env(COMPRESS_ENABLED=(bool, True))
+if env('COMPRESS_ENABLED'):
+    sys.exit(0)
+else:
+    sys.exit(1)
+
+END
+}
+
+if compress_enabled; then
+  # NOTE this command will fail if django-compressor is disabled
   python /app/manage.py compress
 fi
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -6,4 +6,10 @@ set -o nounset
 
 
 python /app/manage.py collectstatic --noinput
+{%- if cookiecutter.use_whitenoise == 'y' and cookiecutter.use_compressor == 'y' %}
+if [ "${COMPRESS_ENABLED:-}" = "True" ];
+then
+  python /app/manage.py compress
+fi
+{%- endif %}
 /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -200,9 +200,27 @@ ANYMAIL = {
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_ENABLED
 COMPRESS_ENABLED = env.bool("COMPRESS_ENABLED", default=True)
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_STORAGE
+{%- if cookiecutter.cloud_provider == 'AWS' %}
 COMPRESS_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+{%- elif cookiecutter.cloud_provider == 'GCP' %}
+COMPRESS_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
+{%- elif cookiecutter.cloud_provider == 'None' %}
+COMPRESS_STORAGE = "compressor.storage.GzipCompressorFileStorage"
+{%- endif %}
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_URL
 COMPRESS_URL = STATIC_URL{% if cookiecutter.use_whitenoise == 'y' or cookiecutter.cloud_provider == 'None' %}  # noqa F405{% endif %}
+{%- if cookiecutter.use_whitenoise == 'y' %}
+# https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_OFFLINE
+COMPRESS_OFFLINE = True  # Offline compression is required when using Whitenoise
+{%- endif %}
+# https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_FILTERS
+COMPRESS_FILTERS = {
+    "css": [
+        "compressor.filters.css_default.CssAbsoluteFilter",
+        "compressor.filters.cssmin.rCSSMinFilter",
+    ],
+    "js": ["compressor.filters.jsmin.JSMinFilter"],
+}
 {% endif %}
 {%- if cookiecutter.use_whitenoise == 'n' -%}
 # Collectfast


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
To change the django compressor setup as well as the startup script for django when required (if using Whitenoise).


## Rationale

[//]: # (Why does the project need that?)
I am propsing to change the django compressor setup for 2 reasons:
1) It currently does not work except when chosing S3 cloud storage
2) Currently no minification is performed on files, making it mostly redundant as this is a major feature of compressor.

The start script is modified when whitenoise is also enabled as compress must then run at start (part of the reason it currently doesn't work).

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
It will improve site speed by minifiying static resources on app start and also fixes a broken setup.

Fixes #2336