### PR TITLE
Remove coreapi requirement

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -87,6 +87,7 @@ Listed in alphabetical order.
   Chris Pappalardo         `@ChrisPappalardo`_
   Christopher Clarke       `@chrisdev`_
   Cole Mackenzie           `@cmackenzie1`_
+  Cole Maclean             `@cole`_                      @cole
   Collederas               `@Collederas`_
   Craig Margieson          `@cmargieson`_
   Cristian Vargas          `@cdvv7788`_
@@ -258,6 +259,7 @@ Listed in alphabetical order.
 .. _@chuckus: https://github.com/chuckus
 .. _@cmackenzie1: https://github.com/cmackenzie1
 .. _@cmargieson: https://github.com/cmargieson
+.. _@cole: https://github.com/cole
 .. _@Collederas: https://github.com/Collederas
 .. _@curtisstpierre: https://github.com/curtisstpierre
 .. _@dadokkio: https://github.com/dadokkio

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -31,4 +31,3 @@ django-redis==4.11.0  # https://github.com/niwinz/django-redis
 
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
-coreapi==2.3.3  # https://github.com/core-api/python-client


### PR DESCRIPTION
##  Description

Removes coreapi from requirements, per https://github.com/pydanny/cookiecutter-django/issues/1969

## Rationale

Coreapi is deprecated and archived, and not appropriate for new projects.

Fixes #1969