### PR TITLE
Add rest_framework.authtoken on installed apps.

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -79,10 +79,9 @@ THIRD_PARTY_APPS = [
 {%- if cookiecutter.use_celery == 'y' %}
     "django_celery_beat",
 {%- endif %}
-{% if cookiecutter.use_drf == "y" -%}
+{%- if cookiecutter.use_drf == "y" %}
     "rest_framework.authtoken",
 {%- endif %}
-
 ]
 
 LOCAL_APPS = [

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -79,6 +79,10 @@ THIRD_PARTY_APPS = [
 {%- if cookiecutter.use_celery == 'y' %}
     "django_celery_beat",
 {%- endif %}
+{% if cookiecutter.use_drf == "y" -%}
+    "rest_framework.authtoken",
+{%- endif %}
+
 ]
 
 LOCAL_APPS = [

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -29,5 +29,7 @@ django-compressor==2.4  # https://github.com/django-compressor/django-compressor
 {%- endif %}
 django-redis==4.11.0  # https://github.com/niwinz/django-redis
 
+{%- if cookiecutter.use_drf == "y" %}
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -28,7 +28,6 @@ django-crispy-forms==1.9.0  # https://github.com/django-crispy-forms/django-cris
 django-compressor==2.4  # https://github.com/django-compressor/django-compressor
 {%- endif %}
 django-redis==4.11.0  # https://github.com/niwinz/django-redis
-
 {%- if cookiecutter.use_drf == "y" %}
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework


### PR DESCRIPTION
Add rest_framework.authtoken on installed apps when the option to use DRF is selected,  because the endpoint '/auth-token/" depends on the said app.
