### PR TITLE
Add PYTHONDONTWRITEBYTECODE flag to local development Dockerfile

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -49,6 +49,7 @@ Listed in alphabetical order.
   Adam Dobrawy             `@ad-m`_
   Adam Steele              `@adammsteele`_
   Agam Dua
+  Agustín Scaramuzza       `@scaramagus`_               @scaramagus
   Alberto Sanchez          `@alb3rto`_
   Alex Tsai                `@caffodian`_
   Alvaro [Andor]           `@andor-pierdelacabeza`_

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7-slim-buster
 
 ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
 
 RUN apt-get update \
   # dependencies for building Python packages


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
This PR adds the PYTHONDONTWRITEBYTECODE environment variable to the local development Dockerfile, according to [the official docs](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE).

## Rationale

[//]: # (Why does the project need that?)

Having `.pyc` files lying around with old changes has caused me (and I can safely assume many others) lots of headaches when coding across multiple branches. This change ensures these files are not created in a local environment and therefore, only `.py` files (with the desired changes) are executed each time.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

When coding on a certain git branch and working on a different feature on a different branch, the Docker image prioritizes `*.pyc` files over `*.py` files, which can cause problems when running `manage.py runserver` or executing migrations.

Fixes #2482