### PR TITLE
Updates default Gitlab CI configuration to fix broken builds on new projects

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -118,6 +118,7 @@ Listed in alphabetical order.
   Garry Cairns             `@garry-cairns`_
   Garry Polley             `@garrypolley`_
   Gilbishkosma             `@Gilbishkosma`_
+  Guilherme Guy            `@guilherme1guy`_
   Hamish Durkin            `@durkode`_
   Hana Quadara             `@hanaquadara`_
   Harry Moreno             `@morenoh149`_                @morenoh149
@@ -275,6 +276,7 @@ Listed in alphabetical order.
 .. _@dhepper: https://github.com/dhepper
 .. _@dot2dotseurat: https://github.com/dot2dotseurat
 .. _@dsclementsen: https://github.com/dsclementsen
+.. _@guilherme1guy: https://github.com/guilherme1guy
 .. _@durkode: https://github.com/durkode
 .. _@Egregors: https://github.com/Egregors
 .. _@epileptic-fish: https://gihub.com/epileptic-fish

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
   POSTGRES_USER: '{{ cookiecutter.project_slug }}'
   POSTGRES_PASSWORD: ''
   POSTGRES_DB: 'test_{{ cookiecutter.project_slug }}'
+  POSTGRES_HOST_AUTH_METHOD: trust
 
 flake8:
   stage: lint


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Fixes https://github.com/pydanny/cookiecutter-django/issues/2489 by adding 'POSTGRES_HOST_AUTH_METHOD=trust' to Gitlab CI runner config


## Rationale

[//]: # (Why does the project need that?)

This change updates Gitlab CI default configuration, so new projects are completing the pipeline when created. 
