### PR TITLE
Remove request_factory fixture, use the rf one from pytest-django

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from django.test import RequestFactory
 
 from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
@@ -13,8 +12,3 @@ def media_storage(settings, tmpdir):
 @pytest.fixture
 def user() -> User:
     return UserFactory()
-
-
-@pytest.fixture
-def request_factory() -> RequestFactory:
-    return RequestFactory()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -16,18 +16,18 @@ class TestUserUpdateView:
         https://github.com/pytest-dev/pytest-django/pull/258
     """
 
-    def test_get_success_url(self, user: User, request_factory: RequestFactory):
+    def test_get_success_url(self, user: User, rf: RequestFactory):
         view = UserUpdateView()
-        request = request_factory.get("/fake-url/")
+        request = rf.get("/fake-url/")
         request.user = user
 
         view.request = request
 
         assert view.get_success_url() == f"/users/{user.username}/"
 
-    def test_get_object(self, user: User, request_factory: RequestFactory):
+    def test_get_object(self, user: User, rf: RequestFactory):
         view = UserUpdateView()
-        request = request_factory.get("/fake-url/")
+        request = rf.get("/fake-url/")
         request.user = user
 
         view.request = request
@@ -36,9 +36,9 @@ class TestUserUpdateView:
 
 
 class TestUserRedirectView:
-    def test_get_redirect_url(self, user: User, request_factory: RequestFactory):
+    def test_get_redirect_url(self, user: User, rf: RequestFactory):
         view = UserRedirectView()
-        request = request_factory.get("/fake-url")
+        request = rf.get("/fake-url")
         request.user = user
 
         view.request = request


### PR DESCRIPTION
## Description

I propose to remove this from our project and use the fixture from pytest-django instead. Not sure if that was a conscious decision, if `rf` wasn't part of pytest-django at the time, or if it was overlooked.

## Rationale

I think we should use existing conventions that most people already know, and avoid creating new ones.
