### PR TITLE
Add unsupported mail_service combinations

### DIFF
--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -73,15 +73,15 @@ cloud_provider:
 mail_service:
     Select an email service that Django-Anymail provides
 
-    1. Amazon SES_
-    2. Mailgun_
+    1. Mailgun_
+    2. `Amazon SES`_
     3. Mailjet_
     4. Mandrill_
     5. Postmark_
     6. SendGrid_
     7. SendinBlue_
     8. SparkPost_
-    9. Plain/Vanilla Django-Anymail_
+    9. `Other SMTP`_
 
 use_drf:
     Indicates whether the project should be configured to use `Django Rest Framework`_.
@@ -114,8 +114,8 @@ ci_tool:
     Select a CI tool for running tests. The choices are:
 
     1. None
-    2. Travis_
-    3. Gitlab_
+    2. `Travis CI`_
+    3. `Gitlab CI`_
 
 keep_local_envs_in_vcs:
     Indicates whether the project's ``.envs/.local/`` should be kept in VCS
@@ -145,7 +145,7 @@ debug:
 .. _AWS: https://aws.amazon.com/s3/
 .. _GCP: https://cloud.google.com/storage/
 
-.. _SES: https://aws.amazon.com/ses/
+.. _Amazon SES: https://aws.amazon.com/ses/
 .. _Mailgun: https://www.mailgun.com
 .. _Mailjet: https://www.mailjet.com
 .. _Mandrill: http://mandrill.com
@@ -153,7 +153,7 @@ debug:
 .. _SendGrid: https://sendgrid.com
 .. _SendinBlue: https://www.sendinblue.com
 .. _SparkPost: https://www.sparkpost.com
-.. _Django-Anymail: https://anymail.readthedocs.io/en/stable/
+.. _Other SMTP: https://anymail.readthedocs.io/en/stable/
 
 .. _Django Rest Framework: https://github.com/encode/django-rest-framework/
 

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -68,3 +68,15 @@ if (
         "You should either use Whitenoise or select a Cloud Provider to serve static files"
     )
     sys.exit(1)
+
+if (
+    "{{ cookiecutter.cloud_provider }}" == "GCP"
+    and "{{ cookiecutter.mail_service }}" == "Amazon SES"
+) or (
+    "{{ cookiecutter.cloud_provider }}" == "None"
+    and "{{ cookiecutter.mail_service }}" == "Amazon SES"
+):
+    print(
+        "You should either use AWS or select a different Mail Service for sending emails."
+    )
+    sys.exit(1)

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -46,17 +46,33 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "AWS", "use_whitenoise": "n"},
     {"cloud_provider": "GCP", "use_whitenoise": "y"},
     {"cloud_provider": "GCP", "use_whitenoise": "n"},
-    {"cloud_provider": "None", "use_whitenoise": "y"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Mailgun"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Mailjet"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Mandrill"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Postmark"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Sendgrid"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "SendinBlue"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "SparkPost"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Other SMTP"},
     # Note: cloud_provider=None AND use_whitenoise=n is not supported
-    {"mail_service": "Mailgun"},
-    {"mail_service": "Amazon SES"},
-    {"mail_service": "Mailjet"},
-    {"mail_service": "Mandrill"},
-    {"mail_service": "Postmark"},
-    {"mail_service": "Sendgrid"},
-    {"mail_service": "SendinBlue"},
-    {"mail_service": "SparkPost"},
-    {"mail_service": "Other SMTP"},
+    {"cloud_provider": "AWS", "mail_service": "Mailgun"},
+    {"cloud_provider": "AWS", "mail_service": "Amazon SES"},
+    {"cloud_provider": "AWS", "mail_service": "Mailjet"},
+    {"cloud_provider": "AWS", "mail_service": "Mandrill"},
+    {"cloud_provider": "AWS", "mail_service": "Postmark"},
+    {"cloud_provider": "AWS", "mail_service": "Sendgrid"},
+    {"cloud_provider": "AWS", "mail_service": "SendinBlue"},
+    {"cloud_provider": "AWS", "mail_service": "SparkPost"},
+    {"cloud_provider": "AWS", "mail_service": "Other SMTP"},
+    {"cloud_provider": "GCP", "mail_service": "Mailgun"},
+    {"cloud_provider": "GCP", "mail_service": "Mailjet"},
+    {"cloud_provider": "GCP", "mail_service": "Mandrill"},
+    {"cloud_provider": "GCP", "mail_service": "Postmark"},
+    {"cloud_provider": "GCP", "mail_service": "Sendgrid"},
+    {"cloud_provider": "GCP", "mail_service": "SendinBlue"},
+    {"cloud_provider": "GCP", "mail_service": "SparkPost"},
+    {"cloud_provider": "GCP", "mail_service": "Other SMTP"},
+    # Note: cloud_providers GCP and None with mail_service Amazon SES is not supported
     {"use_drf": "y"},
     {"use_drf": "n"},
     {"js_task_runner": "None"},
@@ -86,6 +102,8 @@ SUPPORTED_COMBINATIONS = [
 
 UNSUPPORTED_COMBINATIONS = [
     {"cloud_provider": "None", "use_whitenoise": "n"},
+    {"cloud_provider": "GCP", "mail_service": "Amazon SES"},
+    {"cloud_provider": "None", "mail_service": "Amazon SES"},
 ]
 
 
@@ -163,7 +181,7 @@ def test_travis_invokes_pytest(cookies, context):
 
     with open(f"{result.project}/.travis.yml", "r") as travis_yml:
         try:
-            assert yaml.load(travis_yml)["script"] == ["pytest"]
+            assert yaml.load(travis_yml, Loader=yaml.FullLoader)["script"] == ["pytest"]
         except yaml.YAMLError as e:
             pytest.fail(e)
 
@@ -179,7 +197,7 @@ def test_gitlab_invokes_flake8_and_pytest(cookies, context):
 
     with open(f"{result.project}/.gitlab-ci.yml", "r") as gitlab_yml:
         try:
-            gitlab_config = yaml.load(gitlab_yml)
+            gitlab_config = yaml.load(gitlab_yml, Loader=yaml.FullLoader)
             assert gitlab_config["flake8"]["script"] == ["flake8"]
             assert gitlab_config["pytest"]["script"] == ["pytest"]
         except yaml.YAMLError as e:


### PR DESCRIPTION
## Description

Add unsupported mail_service combinations
* Added default yaml Loader for pre_gen_projects.py due to a deprecation warning

## Rationale

The Amazon SES mail_service should not be used with GCP and None cloud providers as it's financially not good and AWS code does not support it due to no credentials.

Also fixed the pytest yaml loader (it's the default, but it gets rid of the deprecation warning)

The deprecation warning:
```
=============================================== warnings summary ================================================
tests/test_cookiecutter_generation.py::test_travis_invokes_pytest
  /Users/andrewwork/Private/code/projects/django/cookiecutter-django/tests/test_cookiecutter_generation.py:185: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    assert yaml.load(travis_yml)["script"] == ["pytest"]

tests/test_cookiecutter_generation.py::test_gitlab_invokes_flake8_and_pytest
  /Users/andrewwork/Private/code/projects/django/cookiecutter-django/tests/test_cookiecutter_generation.py:201: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    gitlab_config = yaml.load(gitlab_yml)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

## Use cases

Fixes #2492