### PR TITLE
Add compress command when using Django Compressor

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -122,6 +122,7 @@ Listed in alphabetical order.
   Garry Cairns             `@garry-cairns`_
   Garry Polley             `@garrypolley`_
   Gilbishkosma             `@Gilbishkosma`_
+  Glenn Wiskur             `@gwiskur`_
   Guilherme Guy            `@guilherme1guy`_
   Hamish Durkin            `@durkode`_
   Hana Quadara             `@hanaquadara`_
@@ -298,6 +299,7 @@ Listed in alphabetical order.
 .. _@garry-cairns: https://github.com/garry-cairns
 .. _@garrypolley: https://github.com/garrypolley
 .. _@Gilbishkosma: https://github.com/Gilbishkosma
+.. _@gwiskur: https://github.com/gwiskur
 .. _@glasslion: https://github.com/glasslion
 .. _@goldhand: https://github.com/goldhand
 .. _@hackebrot: https://github.com/hackebrot

--- a/docs/deployment-on-pythonanywhere.rst
+++ b/docs/deployment-on-pythonanywhere.rst
@@ -15,7 +15,7 @@ Full instructions follow, but here's a high-level view.
 
 2. Set your config variables in the *postactivate* script
 
-3. Run the *manage.py* ``migrate`` and ``collectstatic`` commands
+3. Run the *manage.py* ``migrate`` and ``collectstatic`` {%- if cookiecutter.use_compressor == "y" %}and ``compress`` {%- endif %}commands
 
 4. Add an entry to the PythonAnywhere *Web tab*
 
@@ -109,6 +109,7 @@ Now run the migration, and collectstatic:
     source $VIRTUAL_ENV/bin/postactivate
     python manage.py migrate
     python manage.py collectstatic
+    {%- if cookiecutter.use_compressor == "y" %}python manage.py compress {%- endif %}
     # and, optionally
     python manage.py createsuperuser
 
@@ -175,6 +176,7 @@ For subsequent deployments, the procedure is much simpler.  In a Bash console:
     git pull
     python manage.py migrate
     python manage.py collectstatic
+    {%- if cookiecutter.use_compressor == "y" %}python manage.py compress {%- endif %}
 
 And then go to the Web tab and hit **Reload**
 


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Add ``compress`` command to docs for when using Django Compressor with a PaaS


## Rationale

[//]: # (Why does the project need that?)

I ran into this error when deploying to a PaaS; this PR should keep others from running into the same error.

If the django-compressor option is selected, then the ``compress`` command is required where COMPRESS_OFFLINE = True is default in the production settings.  See here: https://django-compressor.readthedocs.io/en/latest/usage/#offline-compression


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

![image](https://user-images.githubusercontent.com/4186072/78400674-c6eddc00-75bc-11ea-82a2-21bcb2a3a678.png)
