### PR TITLE
Traefik - Also redirect www. to service.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -200,6 +200,7 @@ Listed in alphabetical order.
   Sascha                   `@saschalalala`_             @saschalalala
   Shupeyko Nikita          `@webyneter`_
   Sławek Ehlert            `@slafs`_
+  Sorasful                 `@sorasful`_
   Srinivas Nyayapati       `@shireenrao`_
   stepmr                   `@stepmr`_
   Steve Steiner            `@ssteinerX`_
@@ -372,6 +373,7 @@ Listed in alphabetical order.
 .. _@siauPatrick: https://github.com/siauPatrick
 .. _@sladinji: https://github.com/sladinji
 .. _@slafs: https://github.com/slafs
+.. _@sorasful:: https://github.com/sorasful
 .. _@ssteinerX: https://github.com/ssteinerx
 .. _@step21: https://github.com/step21
 .. _@stepmr: https://github.com/stepmr

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
@@ -28,7 +28,7 @@ certificatesResolvers:
 http:
   routers:
     web-router:
-      rule: "Host(`{{ cookiecutter.domain_name }}`)"
+      rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
       entryPoints:
         - web
       middlewares:
@@ -37,7 +37,7 @@ http:
       service: django
 
     web-secure-router:
-      rule: "Host(`{{ cookiecutter.domain_name }}`)"
+      rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
       entryPoints:
         - web-secure
       middlewares:


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description
I've recently tried to deploy my own project and noticed that some browsers like Google Chrome, Firefox or other redirect automatically when you type www.YOURDOMAIN, I believe they ignore the www and go directly to http://YOURDOMAIN or https://YOURDOMAIN. 
But for other browsers like IE for instance, if you go to www.YOURDOMAIN, you will get an certificate insecure error because www.YOURDOMAIN doesn't match the rule.

[//]: # (What's it you're proposing?)

To add an exception for www subdomain in traefik rules.


## Rationale

[//]: # (Why does the project need that?)

More compatibility with browsers and people often try to access www.YOURDOMAIN .



