### PR TITLE
DEBUG TOOLBAR - fix INTERNAL_IPS discovery for docker

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -112,7 +112,7 @@ Listed in alphabetical order.
   Diane Chen               `@purplediane`_               @purplediane88
   Dónal Adams              `@epileptic-fish`_
   Dong Huynh               `@trungdong`_
-  Duda Nogueira            `@dudanogueira`_                  @dudanogueira
+  Duda Nogueira            `@dudanogueira`_              @dudanogueira
   Emanuel Calso            `@bloodpet`_                  @bloodpet
   Eraldo Energy            `@eraldo`_
   Eric Groom               `@ericgroom`_
@@ -284,6 +284,7 @@ Listed in alphabetical order.
 .. _@dezoito: https://github.com/dezoito
 .. _@dhepper: https://github.com/dhepper
 .. _@dot2dotseurat: https://github.com/dot2dotseurat
+.. _@dudanogueira: https://github.com/dudanogueira
 .. _@dsclementsen: https://github.com/dsclementsen
 .. _@guilherme1guy: https://github.com/guilherme1guy
 .. _@durkode: https://github.com/durkode

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -112,6 +112,7 @@ Listed in alphabetical order.
   Diane Chen               `@purplediane`_               @purplediane88
   Dónal Adams              `@epileptic-fish`_
   Dong Huynh               `@trungdong`_
+  Duda Nogueira            `@dudanogueira`_                  @dudanogueira
   Emanuel Calso            `@bloodpet`_                  @bloodpet
   Eraldo Energy            `@eraldo`_
   Eric Groom               `@ericgroom`_

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -68,7 +68,7 @@ if env("USE_DOCKER") == "yes":
     import socket
 
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS += [".".join(ip.split(".")[:-1]+["1"]) for ip in ips]
+    INTERNAL_IPS += [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips]
 {%- endif %}
 
 # django-extensions

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -68,7 +68,7 @@ if env("USE_DOCKER") == "yes":
     import socket
 
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS += [ip[:-1] + "1" for ip in ips]
+    INTERNAL_IPS += [".".join(ip.split(".")[:-1]+["1"]) for ip in ips]
 {%- endif %}
 
 # django-extensions


### PR DESCRIPTION
A simple fix for the INTERNAL_IPS when using DOCKER

## Rationale

For users with multiple containers, the DEBUG TOOL BAR stops showing up if the django container receives an IP higher than 9, ex 172.19.0.10, it becomes 172.19.0.11, not complying with the INTERNAL_IPS requirement.

The actual code doesn't consider this scenario. This fix will work for all scenarios.

## Use case(s) / visualization(s)
Users that has a stack with numerous containers


