### PR TITLE
Store coverage config in setup.cfg

### DIFF
--- a/{{cookiecutter.project_slug}}/.coveragerc
+++ b/{{cookiecutter.project_slug}}/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-include = {{cookiecutter.project_slug}}/*
-omit = *migrations*, *tests*
-plugins =
-    django_coverage_plugin

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -21,3 +21,9 @@ django_settings_module = config.settings.test
 [mypy-*.migrations.*]
 # Django migrations should not produce any errors:
 ignore_errors = True
+
+[coverage:run]
+include = {{cookiecutter.project_slug}}/*
+omit = *migrations*, *tests*
+plugins =
+    django_coverage_plugin


### PR DESCRIPTION
Less is more. Unify tooling configuration in one file.

https://coverage.readthedocs.io/en/v4.5.x/config.html
