### PR TITLE
Create workflow to generate Changelog via Github action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: Changelog Generator
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Generate changelog content
+      uses: heinrichreimer/action-github-changelog-generator@v2.1.1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Commit changes
+      run: |
+        if [ -n "$(git status --short)" ]
+        then
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "Update Changelog" -a
+        else
+          echo "No changes to commit - skipping"
+        fi
+
+    - name: Push
+      uses: ad-m/github-push-action@v0.5.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: master


### PR DESCRIPTION
## Description

Generate Changelog using Github actions (fixes #1491). The content is generated based on issues and pull requests with labels. It's not including everything I'd like to see yet, as some issues & PRs don't have the right label. It's working with git tags which aren't that useful for cookiecutter templates, but maybe that means we can just create tags more often

## Rationale

Lately, our changelog is not being updated much, and when I have to add the things we've changed recently, it's tedious while it could be easily automated using [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator), and there is now a few github actions doing the job.

## Use case(s) / visualization(s)

This is a cleaned up version of my multiple attempts at getting this to work on another branch. You can see the resulting output here:

https://github.com/pydanny/cookiecutter-django/blob/changelog-generator/CHANGELOG.md