### PR TITLE
Add `container_name` for docker commands locally

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -128,6 +128,7 @@ Listed in alphabetical order.
   Guilherme Guy            `@guilherme1guy`_
   Hamish Durkin            `@durkode`_
   Hana Quadara             `@hanaquadara`_
+  Hannah Lazarus           `@hanhanhan`_
   Harry Moreno             `@morenoh149`_                @morenoh149
   Harry Percival           `@hjwp`_
   Hendrik Schneider        `@hendrikschneider`_

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -154,6 +154,15 @@ django-debug-toolbar
 In order for ``django-debug-toolbar`` to work designate your Docker Machine IP with ``INTERNAL_IPS`` in ``local.py``.
 
 
+docker
+""""""
+
+The ``container_name`` from the yml file can be used to check on containers with docker commands, for example: ::
+
+    $ docker logs worker
+    $ docker top worker
+
+
 Mailhog
 ~~~~~~~
 

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -10,6 +10,7 @@ services:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
     image: {{ cookiecutter.project_slug }}_local_django
+    container_name: django
     depends_on:
       - postgres
       {%- if cookiecutter.use_mailhog == 'y' %}
@@ -29,6 +30,7 @@ services:
       context: .
       dockerfile: ./compose/production/postgres/Dockerfile
     image: {{ cookiecutter.project_slug }}_production_postgres
+    container_name: postgres
     volumes:
       - local_postgres_data:/var/lib/postgresql/data
       - local_postgres_data_backups:/backups
@@ -38,6 +40,7 @@ services:
 
   mailhog:
     image: mailhog/mailhog:v1.0.0
+    container_name: mailhog
     ports:
       - "8025:8025"
 
@@ -46,10 +49,12 @@ services:
 
   redis:
     image: redis:5.0
+    container_name: redis
 
   celeryworker:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_celeryworker
+    container_name: celeryworker
     depends_on:
       - redis
       - postgres
@@ -62,6 +67,7 @@ services:
   celerybeat:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_celerybeat
+    container_name: celerybeat
     depends_on:
       - redis
       - postgres
@@ -74,6 +80,7 @@ services:
   flower:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_flower
+    container_name: flower
     ports:
       - "5555:5555"
     command: /start-flower
@@ -86,6 +93,7 @@ services:
       context: .
       dockerfile: ./compose/local/node/Dockerfile
     image: {{ cookiecutter.project_slug }}_local_node
+    container_name: node
     depends_on:
       - django
     volumes:


### PR DESCRIPTION


[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Add docker-compose configuration `container_name`. This makes it possible to run docker commands without looking up the container hash.

## Examples

`docker exec -it django /bin/bash`
`docker top django`

instead of 

`docker exec -it 5E34B0 /bin/bash`
`docker top 5E34B0`

## Considerations

- Users can't have two containers with the same name. So, if users build multiple cookiecutter-django docker projects locally they will run into this problem. Docker will warn the user to rename the container though.
- Ignored in swarm mode.
- You might not like the names I picked. Do you prefer something closer to the image name for all services?

