### PR TITLE
Improve addition of www redirect to Traefik

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -206,6 +206,7 @@ Listed in alphabetical order.
   Srinivas Nyayapati       `@shireenrao`_
   stepmr                   `@stepmr`_
   Steve Steiner            `@ssteinerX`_
+  Sudarshan Wadkar         `@wadkar`_
   Sule Marshall            `@suledev`_
   Tano Abeleyra            `@tanoabeleyra`_
   Taylor Baldwin
@@ -393,6 +394,7 @@ Listed in alphabetical order.
 .. _@umrashrf: https://github.com/umrashrf
 .. _@viviangb: https://github.com/viviangb
 .. _@vladdoster: https://github.com/vladdoster
+.. _@wadkar: https://github.com/wadkar
 .. _@xpostudio4: https://github.com/xpostudio4
 .. _@yrchen: https://github.com/yrchen
 .. _@yunti: https://github.com/yunti

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
@@ -26,10 +26,9 @@ certificatesResolvers:
         entryPoint: web
 
 http:
-  {%- set domain_dots = cookiecutter.domain_name.count('.') %}
   routers:
     web-router:
-      {%- if domain_dots == 1 or (domain_dots == 2 and '.co.' in cookiecutter.domain_name) %}
+      {%- if cookiecutter.domain_name.count('.') == 1 %}
       rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
       {% else %}
       rule: "Host(`{{ cookiecutter.domain_name }}`)"
@@ -42,7 +41,7 @@ http:
       service: django
 
     web-secure-router:
-      {%- if domain_dots == 1 or (domain_dots == 2 and '.co.' in cookiecutter.domain_name) %}
+      {%- if cookiecutter.domain_name.count('.') == 1 %}
       rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
       {% else %}
       rule: "Host(`{{ cookiecutter.domain_name }}`)"

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
@@ -26,9 +26,10 @@ certificatesResolvers:
         entryPoint: web
 
 http:
+  {%- set domain_dots = cookiecutter.domain_name.count('.') %}
   routers:
     web-router:
-      {%- if len(cookiecutter.domain_name.split('.')) == 2 %}
+      {%- if domain_dots == 1 or (domain_dots == 2 and '.co.' in cookiecutter.domain_name) %}
       rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
       {% else %}
       rule: "Host(`{{ cookiecutter.domain_name }}`)"
@@ -41,7 +42,7 @@ http:
       service: django
 
     web-secure-router:
-      {%- if len(cookiecutter.domain_name.split('.')) == 2 %}
+      {%- if domain_dots == 1 or (domain_dots == 2 and '.co.' in cookiecutter.domain_name) %}
       rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
       {% else %}
       rule: "Host(`{{ cookiecutter.domain_name }}`)"

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
@@ -28,7 +28,11 @@ certificatesResolvers:
 http:
   routers:
     web-router:
+      {%- if len(cookiecutter.domain_name.split('.')) == 2 %}
       rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
+      {% else %}
+      rule: "Host(`{{ cookiecutter.domain_name }}`)"
+      {%- endif %}
       entryPoints:
         - web
       middlewares:
@@ -37,7 +41,11 @@ http:
       service: django
 
     web-secure-router:
+      {%- if len(cookiecutter.domain_name.split('.')) == 2 %}
       rule: "Host(`{{ cookiecutter.domain_name }}`) || Host(`www.{{ cookiecutter.domain_name }}`)"
+      {% else %}
+      rule: "Host(`{{ cookiecutter.domain_name }}`)"
+      {%- endif %}
       entryPoints:
         - web-secure
       middlewares:


### PR DESCRIPTION
Note: Ouch, I deleted the PR template stuff accidentally and a hard refresh won't reload it in the editor.

# Description

PR #2524 adds an additional `www.{{ cookiecutter.domain_name }}` to the traefik route. However, this helpful redirect may not be useful if the `domain_name` itself is a subdomain, e.g. `api.example.com`. In this case an additional `www.api.example.com` route is added to traefik. This PR provides a best effort check for detecting subdomain usage and conditionally adds `www.{{ cookiecutter.domain_name }}` to the traefik route.

# Rationale

As per [this discussion](https://github.com/pydanny/cookiecutter-django/pull/2524#issuecomment-615390917)