### PR TITLE
Update django-redis links

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -34,7 +34,7 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             # Mimicing memcache behavior.
-            # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
+            # http://jazzband.github.io/django-redis/latest/#_memcached_exceptions_behavior
             "IGNORE_EXCEPTIONS": True,
         },
     }

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -31,7 +31,7 @@ django-crispy-forms==1.9.0  # https://github.com/django-crispy-forms/django-cris
 {%- if cookiecutter.use_compressor == "y" %}
 django-compressor==2.4  # https://github.com/django-compressor/django-compressor
 {%- endif %}
-django-redis==4.11.0  # https://github.com/niwinz/django-redis
+django-redis==4.11.0  # https://github.com/jazzband/django-redis
 {%- if cookiecutter.use_drf == "y" %}
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework


### PR DESCRIPTION
**django-redis** was moved to the Jazzband organization ([related issue](https://github.com/jazzband/django-redis/issues/438))