### PR TITLE
Add tests for DRF

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -299,6 +299,8 @@ def remove_aws_dockerfile():
 def remove_drf_starter_files():
     os.remove(os.path.join("config", "api_router.py"))
     shutil.rmtree(os.path.join("{{cookiecutter.project_slug}}", "users", "api"))
+    os.remove(os.path.join("{{cookiecutter.project_slug}}", "users", "tests", "test_drf_urls.py"))
+    os.remove(os.path.join("{{cookiecutter.project_slug}}", "users", "tests", "test_drf_views.py"))
 
 
 def remove_storages_module():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -299,8 +299,16 @@ def remove_aws_dockerfile():
 def remove_drf_starter_files():
     os.remove(os.path.join("config", "api_router.py"))
     shutil.rmtree(os.path.join("{{cookiecutter.project_slug}}", "users", "api"))
-    os.remove(os.path.join("{{cookiecutter.project_slug}}", "users", "tests", "test_drf_urls.py"))
-    os.remove(os.path.join("{{cookiecutter.project_slug}}", "users", "tests", "test_drf_views.py"))
+    os.remove(
+        os.path.join(
+            "{{cookiecutter.project_slug}}", "users", "tests", "test_drf_urls.py"
+        )
+    )
+    os.remove(
+        os.path.join(
+            "{{cookiecutter.project_slug}}", "users", "tests", "test_drf_views.py"
+        )
+    )
 
 
 def remove_storages_module():

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_urls.py
@@ -1,0 +1,24 @@
+import pytest
+from django.urls import resolve, reverse
+
+from {{ cookiecutter.project_slug }}.users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_detail(user: User):
+    assert (
+        reverse("api:user-detail", kwargs={"username": user.username})
+        == f"/api/users/{user.username}/"
+    )
+    assert resolve(f"/api/users/{user.username}/").view_name == "api:user-detail"
+
+
+def test_user_list():
+    assert reverse("api:user-list") == "/api/users/"
+    assert resolve("/api/users/").view_name == "api:user-list"
+
+
+def test_user_me():
+    assert reverse("api:user-me") == "/api/users/me/"
+    assert resolve("/api/users/me/").view_name == "api:user-me"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,0 +1,30 @@
+import pytest
+from django.test import RequestFactory
+
+from {{ cookiecutter.project_slug }}.users.models import User
+from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
+from {{ cookiecutter.project_slug }}.users.api.serializers import UserSerializer
+
+pytestmark = pytest.mark.django_db
+
+
+class TestUserViewSet:
+    def test_get_queryset(self, user: User, rf: RequestFactory):
+        view = UserViewSet()
+        request = rf.get("/fake-url/")
+        request.user = user
+
+        view.request = request
+
+        assert user in view.get_queryset()
+
+    def test_me(self, user: User, rf: RequestFactory):
+        view = UserViewSet()
+        request = rf.get("/fake-url/")
+        request.user = user
+
+        view.request = request
+
+        response = view.me(request)
+
+        assert response.data == UserSerializer(user, context={"request": request}).data

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,9 +1,9 @@
 import pytest
 from django.test import RequestFactory
 
-from {{ cookiecutter.project_slug }}.users.models import User
-from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
 from {{ cookiecutter.project_slug }}.users.api.serializers import UserSerializer
+from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
+from {{ cookiecutter.project_slug }}.users.models import User
 
 pytestmark = pytest.mark.django_db
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,7 +1,6 @@
 import pytest
 from django.test import RequestFactory
 
-from {{ cookiecutter.project_slug }}.users.api.serializers import UserSerializer
 from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
 from {{ cookiecutter.project_slug }}.users.models import User
 
@@ -28,8 +27,8 @@ class TestUserViewSet:
         response = view.me(request)
 
         assert response.data == {
-            "username": user.username, 
-            "email": user.email, 
-            "name": user.name, 
+            "username": user.username,
+            "email": user.email,
+            "name": user.name,
             "url": f"/api/users/{user.username}/",
         }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -27,4 +27,9 @@ class TestUserViewSet:
 
         response = view.me(request)
 
-        assert response.data == UserSerializer(user, context={"request": request}).data
+        assert response.data == {
+            "username": user.username, 
+            "email": user.email, 
+            "name": user.name, 
+            "url": f"/api/users/{user.username}/",
+        }


### PR DESCRIPTION
## Description

Add test case, when `use_drf` option is on.

- Test for drf user urls
  - {{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_urls.py

- Tests for drf user views
  - {{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py

- If use_drf is off, these two test case files remove.

## Rationale

Fixes #2415

## Use case(s) / visualization(s)
