### PR TITLE
Add watchgod for uvicorn

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -18,7 +18,6 @@ flower==0.9.4  # https://github.com/mher/flower
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
 uvicorn==0.11.5  # https://github.com/encode/uvicorn
-gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
 {%- endif %}
 
 # Django

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -8,6 +8,9 @@ psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 {%- else %}
 psycopg2-binary==2.8.5  # https://github.com/psycopg/psycopg2
 {%- endif %}
+{%- if cookiecutter.use_async == 'y' %}
+watchgod==0.6  # https://github.com/samuelcolvin/watchgod
+{%- endif %}
 
 # Testing
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -2,9 +2,7 @@
 
 -r ./base.txt
 
-{%- if cookiecutter.use_async == 'n' %}
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
-{%- endif %}
 psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 {%- if cookiecutter.use_whitenoise == 'n' %}
 Collectfast==2.1.0  # https://github.com/antonagestam/collectfast


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing?)
Use watchgod as recommended by Uvicorn for more efficient reloading when using async.

This is supported since [Uvicorn 0.11.4](https://github.com/encode/uvicorn/blob/master/CHANGELOG.md#0114).

## Rationale

Decrease CPU during development

Also, gunicorn and uvicorn requirements are now properly reorganized according to #2572 

## Use case(s) / visualization(s)


Mostly used for those working asynchronously or with websockets or simply wanting to use ASGI which is faster than WSGI.


