### PR TITLE
Add rabbitmq for celery

### DIFF
--- a/{{cookiecutter.project_slug}}/.envs/.local/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.local/.django
@@ -11,6 +11,9 @@ REDIS_URL=redis://redis:6379/0
 # Celery
 # ------------------------------------------------------------------------------
 
+# RabbitMQ
+RABBITMQ_URL=amqp://user:bitnami@rabbitmq:5672/
+
 # Flower
 CELERY_FLOWER_USER=!!!SET CELERY_FLOWER_USER!!!
 CELERY_FLOWER_PASSWORD=!!!SET CELERY_FLOWER_PASSWORD!!!

--- a/{{cookiecutter.project_slug}}/.envs/.production/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.production/.django
@@ -65,6 +65,9 @@ REDIS_URL=redis://redis:6379/0
 # Celery
 # ------------------------------------------------------------------------------
 
+# RabbitMQ
+RABBITMQ_URL=amqp://user:bitnami@rabbitmq:5672/
+
 # Flower
 CELERY_FLOWER_USER=!!!SET CELERY_FLOWER_USER!!!
 CELERY_FLOWER_PASSWORD=!!!SET CELERY_FLOWER_PASSWORD!!!

--- a/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
+++ b/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
@@ -7,7 +7,7 @@ set -o nounset
 
 {% if cookiecutter.use_celery == 'y' %}
 # N.B. If only .env files supported variable expansion...
-export CELERY_BROKER_URL="${REDIS_URL}"
+export CELERY_BROKER_URL="${RABBITMQ_URL}"
 {% endif %}
 
 if [ -z "${POSTGRES_USER}" ]; then

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -273,7 +273,7 @@ if USE_TZ:
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
 CELERY_BROKER_URL = env("CELERY_BROKER_URL")
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
-CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_RESULT_BACKEND = "rpc"
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_serializer

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -47,16 +47,18 @@ services:
   {%- endif %}
   {%- if cookiecutter.use_celery == 'y' %}
 
-  redis:
-    image: redis:5.0
-    container_name: redis
+  rabbitmq:
+    image: 'bitnami/rabbitmq:latest'
+    container_name: rabbitmq
+    ports:
+      - '5672:5672'
 
   celeryworker:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_celeryworker
     container_name: celeryworker
     depends_on:
-      - redis
+      - rabbitmq
       - postgres
       {% if cookiecutter.use_mailhog == 'y' -%}
       - mailhog
@@ -69,7 +71,7 @@ services:
     image: {{ cookiecutter.project_slug }}_local_celerybeat
     container_name: celerybeat
     depends_on:
-      - redis
+      - rabbitmq
       - postgres
       {% if cookiecutter.use_mailhog == 'y' -%}
       - mailhog
@@ -81,6 +83,8 @@ services:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_flower
     container_name: flower
+    depends_on:
+      - rabbitmq
     ports:
       - "5555:5555"
     command: /start-flower

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -50,6 +50,11 @@ services:
     image: redis:5.0
   {%- if cookiecutter.use_celery == 'y' %}
 
+  rabbitmq:
+    image: 'bitnami/rabbitmq:latest'
+    ports:
+      - '5672:5672'
+
   celeryworker:
     <<: *django
     image: {{ cookiecutter.project_slug }}_production_celeryworker


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Add RabbitMQ for Celery instead of Redis


## Rationale

[//]: # (Why does the project need that?)

Instead of using Redis as the broker, it's best to use RabbitMQ since there's disk failover.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
To this day, the celery docs still say to use RabbitMQ. The result backend uses the performant RPC. If Redis was the broker, and your machine failed for some reason, you can still extract your tasks that you might've delayed for a long time and re-run it, whereas the Redis info would be lost.

