### PR TITLE
Use hiredis

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -36,6 +36,7 @@ CACHES = {
             # Mimicing memcache behavior.
             # http://jazzband.github.io/django-redis/latest/#_memcached_exceptions_behavior
             "IGNORE_EXCEPTIONS": True,
+            "PARSER_CLASS": "redis.connection.HiredisParser",
         },
     }
 }

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -36,7 +36,6 @@ CACHES = {
             # Mimicing memcache behavior.
             # http://jazzband.github.io/django-redis/latest/#_memcached_exceptions_behavior
             "IGNORE_EXCEPTIONS": True,
-            "PARSER_CLASS": "redis.connection.HiredisParser",
         },
     }
 }

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -9,7 +9,9 @@ argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
 {%- endif %}
 redis==3.4.1  # https://github.com/andymccurdy/redis-py
+{%- if cookiecutter.windows == "n" %}
 hiredis==1.0.1  # https://github.com/redis/hiredis-py
+{%- endif %}
 {%- if cookiecutter.use_celery == "y" %}
 celery==4.4.2  # pyup: < 5.0  # https://github.com/celery/celery
 django-celery-beat==2.0.0  # https://github.com/celery/django-celery-beat

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -9,7 +9,7 @@ argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
 {%- endif %}
 redis==3.4.1  # https://github.com/andymccurdy/redis-py
-{%- if cookiecutter.windows == "n" %}
+{%- if cookiecutter.use_docker == "y" or cookiecutter.windows == "n" %}
 hiredis==1.0.1  # https://github.com/redis/hiredis-py
 {%- endif %}
 {%- if cookiecutter.use_celery == "y" %}

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -8,7 +8,8 @@ argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
 {%- if cookiecutter.use_whitenoise == 'y' %}
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
 {%- endif %}
-redis==3.4.1 # https://github.com/andymccurdy/redis-py
+redis==3.4.1  # https://github.com/andymccurdy/redis-py
+hiredis==1.0.1  # https://github.com/redis/hiredis-py
 {%- if cookiecutter.use_celery == "y" %}
 celery==4.4.2  # pyup: < 5.0  # https://github.com/celery/celery
 django-celery-beat==2.0.0  # https://github.com/celery/django-celery-beat

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -12,7 +12,7 @@ Collectfast==2.1.0  # https://github.com/antonagestam/collectfast
 {%- if cookiecutter.use_sentry == "y" %}
 sentry-sdk==0.14.3  # https://github.com/getsentry/sentry-python
 {%- endif %}
-{%- if cookiecutter.use_docker == "y" or cookiecutter.windows == "y" %}
+{%- if cookiecutter.use_docker == "n" and cookiecutter.windows == "y" %}
 hiredis==1.0.1  # https://github.com/redis/hiredis-py
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -12,7 +12,7 @@ Collectfast==2.1.0  # https://github.com/antonagestam/collectfast
 {%- if cookiecutter.use_sentry == "y" %}
 sentry-sdk==0.14.3  # https://github.com/getsentry/sentry-python
 {%- endif %}
-{%- if cookiecutter.windows == "y" %}
+{%- if cookiecutter.use_docker == "y" or cookiecutter.windows == "y" %}
 hiredis==1.0.1  # https://github.com/redis/hiredis-py
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -12,6 +12,9 @@ Collectfast==2.1.0  # https://github.com/antonagestam/collectfast
 {%- if cookiecutter.use_sentry == "y" %}
 sentry-sdk==0.14.3  # https://github.com/getsentry/sentry-python
 {%- endif %}
+{%- if cookiecutter.windows == "y" %}
+hiredis==1.0.1  # https://github.com/redis/hiredis-py
+{%- endif %}
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Using hiredis, which is developed by the redis community, too, is probably best performance wise.

Benchmarks (came when I was using aioredis for websocket pubsub): https://github.com/popravich/python-redis-benchmark

## Rationale

[//]: # (Why does the project need that?)
Since Redis is already used in this project, why not use hiredis? Windows is not supported by Redis and Hiredis; however, Redis could be supported via Docker.

Another thing is most production-ready Django projects don't use Windows servers. So I've put hiredis as a mandatory thing in production (since celery uses redis in local, too, so separate occasions for the hiredis requirements).

## Use case(s) / visualization(s)
[More performant redis](https://github.com/popravich/python-redis-benchmark)

[//]: # ("Better to see something once than to hear about it a thousand times.")


