### PR TITLE
Improve the ROOT_DIR definition

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import environ
 
-ROOT_DIR = Path(__file__).parents[2]
-# {{ cookiecutter.project_slug }}/)
+ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
+# {{ cookiecutter.project_slug }}/
 APPS_DIR = ROOT_DIR / "{{ cookiecutter.project_slug }}"
 env = environ.Env()
 


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing?)

- Make sure to resolve symbolic links, uses an absolute path in `ROOT_DIR`, and raise an error if the path does not exist by using the `resolve` method. https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve 
- Use `parent.parent.parent` because "Explicit is better than simplicity" and because it causes less cognitive overload then `parents[2]`.


## Rationale

[//]: # (Why does the project need that?)

[A similar change](https://github.com/django/django/blob/ba4389a36b5fb1afce0cddb4e28233138b6612b7/django/conf/project_template/project_name/settings.py-tpl#L16) will be sent when django 3.1 is released.
