### PR TITLE
Fix pre-commit config for flake8 & add Black

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -3,18 +3,22 @@ default_stages: [commit]
 fail_fast: true
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: master
     hooks:
       - id: trailing-whitespace
-        files: (^|/).+\.(py|html|sh|css|js)$
+      - id: end-of-file-fixer
+      - id: check-yaml
 
--   repo: local
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
     hooks:
       - id: flake8
-        name: flake8
-        entry: flake8
-        language: python
-        types: [python]
         args: ['--config=setup.cfg']
+        additional_dependencies: [flake8-isort]
 


### PR DESCRIPTION
## Description

Update pre-commit hooks config to use isolated installs of flake8 in order to avoid unpredictible behavior depending on the machine setup.

Also setup pre-commit hook for Black.

## Rationale

Fixes #2502