### PR TITLE
Update Django to 3.0.7 due to CVEs

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -25,7 +25,7 @@ uvicorn==0.11.5  # https://github.com/encode/uvicorn
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.0.5  # pyup: < 3.1  # https://www.djangoproject.com/
+django==3.0.7  # pyup: < 3.1  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
 django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
 django-allauth==0.41.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
There were several CVE's that arose between 3.0.3 to 3.0.7. Updating quickly will resolve the vulnerabilities and fix several PRs.

[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)




## Rationale

[//]: # (Why does the project need that?)




## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")


