### PR TITLE
Fix for gulp watching on windows

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -377,6 +377,7 @@ Listed in alphabetical order.
 .. _@reggieriser: https://github.com/reggieriser
 .. _@reyesvicente: https://github.com/reyesvicente
 .. _@rm--: https://github.com/rm--
+.. _@Tusky: https://github.com/Tusky
 .. _@rolep: https://github.com/rolep
 .. _@romanosipenko: https://github.com/romanosipenko
 .. _@saschalalala: https://github.com/saschalalala

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -199,6 +199,7 @@ Listed in alphabetical order.
   Raphael Pierzina         `@hackebrot`_
   Reggie Riser             `@reggieriser`_
   René Muhl                `@rm--`_
+  Richard Hajdu            `@Tusky`_
   Roman Afanaskin          `@siauPatrick`_
   Roman Osipenko           `@romanosipenko`_
   Russell Davies

--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -163,9 +163,9 @@ function initBrowserSync() {
 
 // Watch
 function watchPaths() {
-  watch(`${paths.sass}/*.scss`, styles)
-  watch(`${paths.templates}/**/*.html`).on("change", reload)
-  watch([`${paths.js}/*.js`, `!${paths.js}/*.min.js`], scripts).on("change", reload)
+  watch(`${paths.sass}/*.scss`{% if cookiecutter.windows == 'y' %}, { usePolling: true }{% endif %}, styles)
+  watch(`${paths.templates}/**/*.html`{% if cookiecutter.windows == 'y' %}, { usePolling: true }{% endif %}).on("change", reload)
+  watch([`${paths.js}/*.js`, `!${paths.js}/*.min.js`]{% if cookiecutter.windows == 'y' %}, { usePolling: true }{% endif %}, scripts).on("change", reload)
 }
 
 // Generate all assets


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)
Fix for browsersync and file watchers not working correctly on windows. This uses a legacy polling method, so it registers events if the user is on windows (which I assume the **windows?** is meant to represent.

Fixes #2642 which I've encountered.



## Rationale

[//]: # (Why does the project need that?)
There are some windows developers around, and cookiecutter-django is a great start for a project whatever OS you use.



## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")
Not much to visualize sadly, but I think it's a pretty simple PR to understand what it does :)

