### PR TITLE
Add author name and description to HTML meta

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -5,8 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}{% endraw %}{{ cookiecutter.project_name }}{% raw %}{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="{{ cookiecutter.description }}">
-    <meta name="author" content="{{ cookiecutter.author_name }}">
+    <meta name="description" content="{% endraw %}{{ cookiecutter.description }}{% raw %}">
+    <meta name="author" content="{% endraw %}{{ cookiecutter.author_name }}{% raw %}">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -5,8 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}{% endraw %}{{ cookiecutter.project_name }}{% raw %}{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
-    <meta name="author" content="">
+    <meta name="description" content="{{ cookiecutter.description }}">
+    <meta name="author" content="{{ cookiecutter.author_name }}">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Base.html has author name and description meta tags, but the cookiecutter generation never adds it in.


## Rationale

[//]: # (Why does the project need that?)

META tags just help a website out.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

Why waste the initial user input?

Edit: sorry for the constant PRs. I continuously use cookiecutter-django, so I just keep stumbling upon areas to touch up or add on to.