### PR TITLE
Add entrypoint for docs to not error on build

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -24,6 +24,12 @@ COPY ./requirements /requirements
 # All imports needed for autodoc.
 RUN pip install -r /requirements/local.txt -r /requirements/production.txt
 
+COPY ./compose/production/django/entrypoint /entrypoint
+RUN sed -i 's/\r$//g' /entrypoint
+RUN chmod +x /entrypoint
+
 WORKDIR /docs
+
+ENTRYPOINT ["/entrypoint"]
 
 CMD make livehtml

--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -28,8 +28,10 @@ COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
 
+COPY ./compose/local/docs/start /start-docs
+RUN sed -i 's/\r$//g' /start-docs
+RUN chmod +x /start-docs
+
 WORKDIR /docs
 
 ENTRYPOINT ["/entrypoint"]
-
-CMD make livehtml

--- a/{{cookiecutter.project_slug}}/compose/local/docs/start
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+make livehtml

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -43,6 +43,8 @@ services:
     build:
       context: .
       dockerfile: ./compose/local/docs/Dockerfile
+    depends_on:
+      - postgres
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -45,6 +45,7 @@ services:
       dockerfile: ./compose/local/docs/Dockerfile
     env_file:
       - ./.envs/.local/.django
+      - ./.envs/.local/.postgres
     volumes:
       - ./docs:/docs
       - ./config:/app/config

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -52,6 +52,7 @@ services:
       - ./{{ cookiecutter.project_slug }}:/app/{{ cookiecutter.project_slug }}
     ports:
       - "7000:7000"
+    command: /start-docs
     
   {%- if cookiecutter.use_mailhog == 'y' %}
 


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.rst` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Docker building the docs error unless you add entry point to configure the database.

## Rationale

[//]: # (Why does the project need that?)

You see nothing unless you can build the docs... so you need to make sure Django is actually setup.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

To see the docs.

~~Note: I wonder if we can do what we do for celery which is using anchors. The command: sphinx-autobuild -b html -H 0.0.0.0 -p 7000 --watch /app -c . ./_source ./_build/html~~ Still would need production.txt...

Fixes #2712 