### PR TITLE
Update requirements to include django-cors-headers with DRF [PR #2650]

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -44,6 +44,7 @@ Listed in alphabetical order.
   18                       `@dezoito`_
   2O4                      `@2O4`_
   a7p                      `@a7p`_
+  Aadith PM                `@aadithpm`_
   Aaron Eikenberry         `@aeikenberry`_
   Adam Bogdał              `@bogdal`_
   Adam Dobrawy             `@ad-m`_

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -236,6 +236,7 @@ Listed in alphabetical order.
   Yuchen Xie               `@mapx`_
 ========================== ============================ ==============
 
+.. _@aadithpm: https://github.com/aadithpm
 .. _@a7p: https://github.com/a7p
 .. _@2O4: https://github.com/2O4
 .. _@ad-m: https://github.com/ad-m

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -328,7 +328,7 @@ REST_FRAMEWORK = {
 
 # django-cors-headers - https://github.com/adamchainz/django-cors-headers#setup
 CORS_URLS_REGEX = {
-    r'^/api.*$',
+    r"^/api.*$",
 }
 
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -80,6 +80,7 @@ THIRD_PARTY_APPS = [
 {%- if cookiecutter.use_drf == "y" %}
     "rest_framework",
     "rest_framework.authtoken",
+    "corsheaders",
 {%- endif %}
 ]
 
@@ -134,6 +135,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+{%- if cookiecutter.use_drf == 'y' %}
+    "corsheaders.middleware.CorsMiddleware",
+{%- endif %}
 {%- if cookiecutter.use_whitenoise == 'y' %}
     "whitenoise.middleware.WhiteNoiseMiddleware",
 {%- endif %}
@@ -321,6 +325,12 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
 }
+
+# django-cors-headers - https://github.com/adamchainz/django-cors-headers#setup
+CORS_URLS_REGEX = {
+    r'^/api.*$',
+}
+
 {%- endif %}
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -327,9 +327,7 @@ REST_FRAMEWORK = {
 }
 
 # django-cors-headers - https://github.com/adamchainz/django-cors-headers#setup
-CORS_URLS_REGEX = {
-    r"^/api.*$",
-}
+CORS_URLS_REGEX = r"^/api/.*$"
 
 {%- endif %}
 # Your stuff...

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -41,4 +41,6 @@ django-redis==4.12.1  # https://github.com/jazzband/django-redis
 {%- if cookiecutter.use_drf == "y" %}
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
+# Django CORS Headers
+django-cors-headers==0.01 # https://github.com/adamchainz/django-cors-headers
 {%- endif %}


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing?)

Adding `django_cors_headers` as a part of requirements when a project includes Django REST Framework (DRF). This was brought up in issue #2650.


## Rationale

[//]: # (Why does the project need that?)

Data from DRF usually requires CORS to be consumed. `django-cors-headers` is installed for a DRF project to get past this, so adding it by default to DRF projects will help. 

Fixes #2650

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

* Create a new Django (or any framework, for that matter) project
* Create a REST endpoint on your backend that returns some placeholder data
* Try to consume this endpoint on a front-end on a different origin - you will receive a Same Origin Policy error
* Use a CORS middleware to bypass this  
