### PR TITLE
Be explicit in context processor

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
@@ -2,5 +2,7 @@ from django.conf import settings
 
 
 def settings_context(_request):
-    # Be explicit
+    """Settings available by default to the templates context."""
+    # Note: we intentionally do NOT expose the entire settings
+    # to prevent accidental leaking of sensitive information
     return {"DEBUG": settings.DEBUG}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
@@ -2,4 +2,5 @@ from django.conf import settings
 
 
 def settings_context(_request):
-    return {"settings": settings}
+    # Be explicit
+    return {"DEBUG": settings.DEBUG}


### PR DESCRIPTION
Closes #2670 Closes #2614 

## Description

Explicit dict for context processor.

## Rationale

Although it poses a security risk if a developer accidentally exposes something like a key, I think a general risk would be if someone were using some CI and env vars were exposed like that.

General practicing though, it makes developers more keen and hopefully more cautious on what they're putting in a Django template.

## Use case(s) / visualization(s)

Better Django dev habits.


