### PR TITLE
Import base requirements without the leading dot

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,4 +1,4 @@
--r ./base.txt
+-r base.txt
 
 Werkzeug==1.0.1 # https://github.com/pallets/werkzeug
 ipdb==0.13.3  # https://github.com/gotcha/ipdb

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -1,6 +1,6 @@
 # PRECAUTION: avoid production dependencies that aren't in development
 
--r ./base.txt
+-r base.txt
 
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
 psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2


### PR DESCRIPTION
## Description

Lately, we haven't been receiving updates from Pyup which are specified in the `base.txt` file (see https://github.com/pyupio/pyup/issues/390).

After some investigation, it looks like this is because we include base from production with a leading `.`.

Let's try to remove the dot to see if it fixes the issue.

## Rationale

Keep the project up to date more easily.