### PR TITLE
Run isort as pre-commit hook

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -141,6 +141,7 @@ Listed in alphabetical order.
   Isaac12x                 `@Isaac12x`_
   Ivan Khomutov            `@ikhomutov`_
   James Williams           `@jameswilliams1`_
+  Jan Fabry                `@janfabry`_
   Jan Van Bruggen          `@jvanbrug`_
   Jelmer Draaijer          `@foarsitter`_
   Jerome Caisip            `@jeromecaisip`_
@@ -331,6 +332,7 @@ Listed in alphabetical order.
 .. _@ikkebr: https://github.com/ikkebr
 .. _@Isaac12x: https://github.com/Isaac12x
 .. _@iynaix: https://github.com/iynaix
+.. _@janfabry: https://github.com/janfabry
 .. _@jangeador: https://github.com/jangeador
 .. _@jazztpt: https://github.com/jazztpt
 .. _@jcass77: https://github.com/jcass77
@@ -392,7 +394,7 @@ Listed in alphabetical order.
 .. _@siauPatrick: https://github.com/siauPatrick
 .. _@sladinji: https://github.com/sladinji
 .. _@slafs: https://github.com/slafs
-.. _@sorasful:: https://github.com/sorasful
+.. _@sorasful: https://github.com/sorasful
 .. _@ssteinerX: https://github.com/ssteinerx
 .. _@step21: https://github.com/step21
 .. _@stepmr: https://github.com/stepmr

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:


### PR DESCRIPTION
Run it before flake8, so any errors will get fixed automatically.

Fixes #2711 

Should we also remove flake8-isort from the flake8 check? And remove the flake8-isort requirement?

It's not clear to me yet whether pre-commit runs and installs its hooks in the same environment you are using, or in a separate virtualenv, so I don't know if it is an issue someone already has an older isort installed.
