### PR TITLE
Add STATICFILES_STORAGE with compressor support

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -242,7 +242,7 @@ COMPRESS_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 COMPRESS_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 {%- elif cookiecutter.cloud_provider == 'AWS' or cookiecutter.cloud_provider == 'GCP' %}
 COMPRESS_STORAGE = STATICFILES_STORAGE
-COMPRESS_ROOT = STATIC_ROOT
+COMPRESS_ROOT = STATIC_ROOT  # noqa F405 
 {%- elif cookiecutter.cloud_provider == 'None' %}
 COMPRESS_STORAGE = "compressor.storage.GzipCompressorFileStorage"
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -235,16 +235,11 @@ ANYMAIL = {}
 # ------------------------------------------------------------------------------
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_ENABLED
 COMPRESS_ENABLED = env.bool("COMPRESS_ENABLED", default=True)
-# https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_STORAGE
-{%- if cookiecutter.cloud_provider == 'AWS' and cookiecutter.use_whitenoise == 'y' %}
-COMPRESS_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-{%- elif cookiecutter.cloud_provider == 'GCP' and cookiecutter.use_whitenoise == 'y' %}
-COMPRESS_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
-{%- elif cookiecutter.cloud_provider == 'AWS' or cookiecutter.cloud_provider == 'GCP' %}
-COMPRESS_STORAGE = STATICFILES_STORAGE
-COMPRESS_ROOT = STATIC_ROOT  # noqa F405 
-{%- elif cookiecutter.cloud_provider == 'None' %}
+{%- if cookiecutter.cloud_provider == 'None' %}
 COMPRESS_STORAGE = "compressor.storage.GzipCompressorFileStorage"
+{%- elif cookiecutter.cloud_provider in ('AWS', 'GCP') and cookiecutter.use_whitenoise == 'n' %}
+# https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_STORAGE
+COMPRESS_STORAGE = STATICFILES_STORAGE
 {%- endif %}
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_URL
 COMPRESS_URL = STATIC_URL{% if cookiecutter.use_whitenoise == 'y' or cookiecutter.cloud_provider == 'None' %}  # noqa F405{% endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -236,10 +236,12 @@ ANYMAIL = {}
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_ENABLED
 COMPRESS_ENABLED = env.bool("COMPRESS_ENABLED", default=True)
 # https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_STORAGE
-{%- if cookiecutter.cloud_provider == 'AWS' %}
+{%- if cookiecutter.cloud_provider == 'AWS' and cookiecutter.use_whitenoise == 'y' %}
 COMPRESS_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-{%- elif cookiecutter.cloud_provider == 'GCP' %}
+{%- elif cookiecutter.cloud_provider == 'GCP' and cookiecutter.use_whitenoise == 'y' %}
 COMPRESS_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
+{%- elif cookiecutter.cloud_provider == 'AWS' or cookiecutter.cloud_provider == 'GCP' %}
+COMPRESS_STORAGE = STATICFILES_STORAGE
 {%- elif cookiecutter.cloud_provider == 'None' %}
 COMPRESS_STORAGE = "compressor.storage.GzipCompressorFileStorage"
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -242,6 +242,7 @@ COMPRESS_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 COMPRESS_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 {%- elif cookiecutter.cloud_provider == 'AWS' or cookiecutter.cloud_provider == 'GCP' %}
 COMPRESS_STORAGE = STATICFILES_STORAGE
+COMPRESS_ROOT = STATIC_ROOT
 {%- elif cookiecutter.cloud_provider == 'None' %}
 COMPRESS_STORAGE = "compressor.storage.GzipCompressorFileStorage"
 {%- endif %}


### PR DESCRIPTION
Fixes #2739

## Description

`COMPRESSOR_STORAGE` should be set to `STATICFILES_STORAGE` if not using whitenoise and using something like AWS S3.


## Rationale

Compressor cache is stored in the AWS bucket in a separate file structure. For example, without this PR, the files would not have an ACL of public-read:

```
- CACHE
- static
- media
```

With this PR:

```
- static
    - CACHE
- media
```

The static files storage is set to S3, but the utils (in cookiecutter.project_slug.utils.storages) are set up only for the original collectstatic command, not for compressor support. Thus, compressor would store stuff inside its own directory that did not have public-read.

## Use case(s) / visualization(s)

Allow compressor directory of CACHE to be publicly viewable in storage buckets.
