### PR TITLE
Update linters.rst

### DIFF
--- a/docs/linters.rst
+++ b/docs/linters.rst
@@ -19,7 +19,7 @@ The config for flake8 is located in setup.cfg. It specifies:
 pylint
 ------
 
-This is included in flake8's checks, but you can also run it separately to see a more detailed report: ::
+To run pylint: ::
 
     $ pylint <python files that you wish to lint>
 


### PR DESCRIPTION
Related to #2744 issue.

pylint is not included in flake8 as the documentation states. It needs to be executed separately.


Fixes #2744 