### PR TITLE
Add ReadTheDocs Support

### DIFF
--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+
+python:
+  version: 3.8
+  install:
+    - requirements: requirements/local.txt

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -14,11 +14,20 @@ import os
 import sys
 import django
 
+if os.getenv("READTHEDOCS", default=False) == "True":
+    sys.path.insert(0, os.path.abspath(".."))
+    os.environ["DJANGO_READ_DOT_ENV_FILE"] = "True"
+    {% if cookiecutter.use_celery == 'y' -%}
+    os.environ["CELERY_BROKER_URL"] = os.getenv("REDIS_URL", "redis://redis:6379")
+    {%- endif %}
+    os.environ["USE_DOCKER"] = "no"
+    master_doc = "_source/index"
+else:
 {% if cookiecutter.use_docker == 'y' %}
-sys.path.insert(0, os.path.abspath("/app"))
-os.environ.setdefault("DATABASE_URL", "")
+    sys.path.insert(0, os.path.abspath("/app"))
+    os.environ.setdefault("DATABASE_URL", "")
 {% else %}
-sys.path.insert(0, os.path.abspath(".."))
+    sys.path.insert(0, os.path.abspath(".."))
 {%- endif %}
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
 django.setup()

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -17,16 +17,16 @@ import django
 if os.getenv("READTHEDOCS", default=False) == "True":
     sys.path.insert(0, os.path.abspath(".."))
     os.environ["DJANGO_READ_DOT_ENV_FILE"] = "True"
-    {% if cookiecutter.use_celery == 'y' -%}
+    {%- if cookiecutter.use_celery == 'y' %}
     os.environ["CELERY_BROKER_URL"] = os.getenv("REDIS_URL", "redis://redis:6379")
     {%- endif %}
     os.environ["USE_DOCKER"] = "no"
     master_doc = "_source/index"
 else:
-{% if cookiecutter.use_docker == 'y' %}
+{%- if cookiecutter.use_docker == 'y' %}
     sys.path.insert(0, os.path.abspath("/app"))
     os.environ.setdefault("DATABASE_URL", "")
-{% else %}
+{%- else %}
     sys.path.insert(0, os.path.abspath(".."))
 {%- endif %}
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")


### PR DESCRIPTION
Fixes #2733 
## Description

Add RTD support for websites.

* Test repository: https://github.com/Andrew-Chen-Wang/test-cookiecutter-django-rtd
* Sample URL (old version looking): https://test-cookiecutter-django-rtd.readthedocs.io/en/v1/_source/index.html
* Sample URL (modern version looking): https://test-cookiecutter-django-rtd.readthedocs.io/en/latest/_source/index.html

## Rationale

Some people with websites may want to add documentation in their code, whether private for enterprise or public for [open source websites](https://donate-anything.org).

## Use case(s) / visualization(s)

* Issue: you must go to /_source for this to work due to how the docs/* configuration is setup up.

To enable that modern looking RTD, check out https://github.com/readthedocs/sphinx_rtd_theme. Go to conf.py and add that to the extensions (make sure it's in the requirements file).

You can have something like this (below the extensions list):
```
if os.getenv("READTHEDOCS", default=False) == "True":
    import sphinx_rtd_theme
    extensions += ["sphinx_rtd_theme"]
    html_theme = "sphinx_rtd_theme"
else:
    html_theme = "alabaster"
```
Imo, more people would like that first part rather than the alabaster format.