### PR TITLE
Reference production.txt in local.txt for installing production requi…

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,12 +1,8 @@
 -r base.txt
+-r production.txt
 
 Werkzeug==1.0.1 # https://github.com/pallets/werkzeug
 ipdb==0.13.3  # https://github.com/gotcha/ipdb
-{%- if cookiecutter.use_docker == 'y' %}
-psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
-{%- else %}
-psycopg2-binary==2.8.5  # https://github.com/psycopg/psycopg2
-{%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
 watchgod==0.6  # https://github.com/samuelcolvin/watchgod
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -3,7 +3,11 @@
 -r base.txt
 
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
+{%- if cookiecutter.use_docker == 'y' %}
 psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
+{%- else %}
+psycopg2-binary==2.8.5  # https://github.com/psycopg/psycopg2
+{%- endif %}
 {%- if cookiecutter.use_whitenoise == 'n' %}
 Collectfast==2.2.0  # https://github.com/antonagestam/collectfast
 {%- endif %}


### PR DESCRIPTION
## Description

[//]: # (What's it you're proposing? How should it be implemented?)

My proposal is to install production.txt requirements in the dev/local environment. 

## Rationale

[//]: # (Why should this feature be implemented?)

A lot of stuff for development is not necessary for production. The other way around is it no problem to have a few extra dependencies around in development. 

## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

- When editing production.py, I face missing reference and cannot use autocomplete features of my IDE. 
- Developing a storage backend requires django-storages. 
