### PR TITLE
Add environment and traces_sample_rate keyword to sentry_sdk.init

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -49,6 +49,8 @@ DJANGO_AWS_S3_CUSTOM_DOMAIN             AWS_S3_CUSTOM_DOMAIN        n/a         
 DJANGO_GCP_STORAGE_BUCKET_NAME          GS_BUCKET_NAME              n/a                                            raises error
 GOOGLE_APPLICATION_CREDENTIALS          n/a                         n/a                                            raises error
 SENTRY_DSN                              SENTRY_DSN                  n/a                                            raises error
+SENTRY_ENVIRONMENT                      n/a                         n/a                                            production
+SENTRY_TRACES_SAMPLE_RATE               n/a                         n/a                                            0.0
 DJANGO_SENTRY_LOG_LEVEL                 SENTRY_LOG_LEVEL            n/a                                            logging.INFO
 MAILGUN_API_KEY                         MAILGUN_API_KEY             n/a                                            raises error
 MAILGUN_DOMAIN                          MAILGUN_SENDER_DOMAIN       n/a                                            raises error

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -353,13 +353,17 @@ sentry_logging = LoggingIntegration(
 )
 
 {%- if cookiecutter.use_celery == 'y' %}
+integrations = [sentry_logging, DjangoIntegration(), CeleryIntegration()]
+{% else %}
+integrations = [sentry_logging, DjangoIntegration()]
+{% endif -%}
+
 sentry_sdk.init(
     dsn=SENTRY_DSN,
-    integrations=[sentry_logging, DjangoIntegration(), CeleryIntegration()],
+    integrations=integrations,
+    environment=env("SENTRY_ENVIRONMENT", default="production"),
+    traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=0.0),
 )
-{% else %}
-sentry_sdk.init(dsn=SENTRY_DSN, integrations=[sentry_logging, DjangoIntegration()])
-{% endif -%}
 {% endif %}
 # Your stuff...
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Introduce the `SENTRY_ENVIRONMENT` and `SENTRY_TRACES_SAMPLE_RATE` environment variables. 

`SENTRY_ENVIRONMENT`: use the same API key across multiple environments with defining an environment: https://docs.sentry.io/product/sentry-basics/environments/

`SENTRY_TRACES_SAMPLE_RATE`: used for tracking performance in sentry: https://docs.sentry.io/product/performance/. Use `0.0` for disabled and `1.0` for sending in each request. Read more info about the configuration: https://docs.sentry.io/product/performance/getting-started/?platform=python