### PR TITLE
Remove --no-binary option for psycopg2

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -3,7 +3,7 @@
 Werkzeug==1.0.1 # https://github.com/pallets/werkzeug
 ipdb==0.13.3  # https://github.com/gotcha/ipdb
 {%- if cookiecutter.use_docker == 'y' %}
-psycopg2==2.8.6 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
+psycopg2==2.8.6  # https://github.com/psycopg/psycopg2
 {%- else %}
 psycopg2-binary==2.8.6  # https://github.com/psycopg/psycopg2
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -3,7 +3,7 @@
 -r base.txt
 
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
-psycopg2==2.8.6 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
+psycopg2==2.8.6  # https://github.com/psycopg/psycopg2
 {%- if cookiecutter.use_whitenoise == 'n' %}
 Collectfast==2.2.0  # https://github.com/antonagestam/collectfast
 {%- endif %}


### PR DESCRIPTION
## Description

Remove --no-binary option for psycopg2 in requiremnts files.

## Rationale

It was required in 2.7, but it's now the default in 2.8:

https://www.psycopg.org/docs/install.html#change-in-binary-packages-between-psycopg-2-7-and-2-8

Looks like using this option prevents PyUP to send updates.