### PR TITLE
Fix options for sphinx-autobuild in docs Makefile

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -22,9 +22,9 @@ help:
 # Build, watch and serve docs with live reload
 livehtml:
 	sphinx-autobuild -b html 
-	{%- if cookiecutter.use_docker == 'y' %} -H 0.0.0.0 
+	{%- if cookiecutter.use_docker == 'y' %} --host 0.0.0.0
 	{%- else %} --open-browser 
-	{%- endif %} -p 7000 --watch $(APP) -c . $(SOURCEDIR) $(BUILDDIR)/html
+	{%- endif %} --port 7000 --watch $(APP) -c . $(SOURCEDIR) $(BUILDDIR)/html
 
 # Outputs rst files from django application code
 apidocs:


### PR DESCRIPTION
## Description

Fix options for sphinx-autobuild in docs Makefile.

## Rationale

Looks like the shorthand was removed in the latest release.

## Use case(s) / visualization(s)

Fix #2796


