### PR TITLE
Clean up nested venv files from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,16 +208,6 @@ Session.vim
 tags
 
 
-### VirtualEnv template
-# Virtualenv
-# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
-[Ii]nclude
-[Ll]ib
-[Ll]ib64
-pyvenv.cfg
-pip-selfcheck.json
-
-
 # Even though the project might be opened and edited
 # in any of the JetBrains IDEs, it makes no sence whatsoever
 # to 'run' anything within it since any particular cookiecutter

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -321,18 +321,6 @@ Session.vim
 
 # Auto-generated tag files
 tags
-{% if cookiecutter.use_docker == 'n' %}
-
-### VirtualEnv template
-# Virtualenv
-[Ii]nclude
-[Ll]ib
-[Ll]ib64
-[Ss]cripts
-pyvenv.cfg
-pip-selfcheck.json
-.env
-{% endif %}
 
 ### Project template
 {% if cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'n' %}


### PR DESCRIPTION
## Description

Remove files from virtualenv from .gitignore as parent should already be excluded.


## Rationale

These files may be created for other purposes like `django-extensions`, Heroku or for various CI scripts.


## Use case(s) / visualization(s)

Fixes #2226


