### PR TITLE
Add moto to local.txt

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -17,6 +17,9 @@ mypy==0.770  # https://github.com/python/mypy
 django-stubs==1.5.0  # https://github.com/typeddjango/django-stubs
 pytest==6.0.1  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.4  # https://github.com/Frozenball/pytest-sugar
+{%- if cookiecutter.cloud_provider == 'AWS' %}
+moto==1.3.16  # https://github.com/spulec/moto
+{%- endif %}
 
 # Documentation
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

I've added Moto, a mock AWS service library, designed to for helping test your boto3 code. 

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Although this repository doesn't use boto3 in development since it uses Django-storages, for others writing stuff like presigned posts or testing other methods of uploading media (e.g. ML checking if the image has at least one face), it'd be great to have something like this.

That's when moto comes in: instead of continuously sending requests to your S3 bucket especially during CI, incurring lots of costs, just use the mock service during testing.
