### PR TITLE
Making docs file smaller by around 40% using multi-stage builds

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -63,8 +63,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 
 # copy python dependencies from python-build-stage
-COPY --from=build_stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
-COPY --from=build_stage /usr/local/bin/ /usr/local/bin/
+COPY --from=python-build-stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
+COPY --from=python-build-stage /usr/local/bin/ /usr/local/bin/
 
 
 

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -1,22 +1,31 @@
+# Python build stage
+FROM python:3.8-slim-buster as python-build-stage
+ENV PYTHONDONTWRITEBYTECODE 1
+
+# Requirements are installed here to ensure they will be cached.
+COPY ./requirements /requirements
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  # dependencies for building Python packages
+  build-essential \
+  # psycopg2 dependencies
+  libpq-dev \
+  # Translations dependencies
+  gettext \
+  # cleaning up unused files
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/* \
+  # create python dependency wheels
+  && pip wheel --no-cache-dir --no-deps --use-feature=2020-resolver --wheel-dir /usr/src/app/wheels -r /requirements/production.txt \
+  && rm -rf /requirements
+
+
+
+# Python 'run' stage
 FROM python:3.8-slim-buster
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
-
-RUN apt-get update \
-  # dependencies for building Python packages
-  && apt-get install -y build-essential \
-  # psycopg2 dependencies
-  && apt-get install -y libpq-dev \
-  # Translations dependencies
-  && apt-get install -y gettext \
-  # cleaning up unused files
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/*
-
-# Requirements are installed here to ensure they will be cached.
-COPY ./requirements /requirements
-RUN pip install -r /requirements/local.txt
 
 COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
@@ -25,6 +34,7 @@ RUN chmod +x /entrypoint
 COPY ./compose/local/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
+
 {% if cookiecutter.use_celery == "y" %}
 COPY ./compose/local/django/celery/worker/start /start-celeryworker
 RUN sed -i 's/\r$//g' /start-celeryworker
@@ -38,6 +48,27 @@ COPY ./compose/local/django/celery/flower/start /start-flower
 RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 {% endif %}
+
+
+# installing required system dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  # psycopg2 dependencies
+  libpq-dev \
+  # Translations dependencies
+  gettext \
+  # cleaning up unused files
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/*
+
+
+# copy python dependency wheels from python-build-stage
+COPY --from=python-build-stage /usr/src/app/wheels /wheels
+
+# install python dependencies
+RUN pip install --no-cache /wheels/*
+
+
+
 WORKDIR /app
 
 ENTRYPOINT ["/entrypoint"]

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/* \
   # create python dependency wheels
-  && pip wheel --no-cache-dir --no-deps --use-feature=2020-resolver --wheel-dir /usr/src/app/wheels -r /requirements/production.txt \
+  && pip wheel --no-cache-dir --no-deps --use-feature=2020-resolver --wheel-dir /usr/src/app/wheels -r /requirements/local.txt \
   && rm -rf /requirements
 
 

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/* \
-  # create python dependency wheels
-  && pip wheel --no-cache-dir --no-deps --use-feature=2020-resolver --wheel-dir /usr/src/app/wheels -r /requirements/local.txt \
+  # install python dependencies
+  && pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/local.txt \
   && rm -rf /requirements
 
 
@@ -61,11 +61,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && rm -rf /var/lib/apt/lists/*
 
 
-# copy python dependency wheels from python-build-stage
-COPY --from=python-build-stage /usr/src/app/wheels /wheels
 
-# install python dependencies
-RUN pip install --no-cache /wheels/*
+# copy python dependencies from python-build-stage
+COPY --from=build_stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
+COPY --from=build_stage /usr/local/bin/ /usr/local/bin/
 
 
 

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -2,9 +2,6 @@
 FROM python:3.8-slim-buster as python-build-stage
 ENV PYTHONDONTWRITEBYTECODE 1
 
-# Requirements are installed here to ensure they will be cached.
-COPY ./requirements /requirements
-
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
@@ -14,15 +11,19 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   gettext \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/* \
-  # install python dependencies
-  && pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/local.txt \
-  && rm -rf /requirements
+  && rm -rf /var/lib/apt/lists/*
+
+# Requirements are installed here to ensure they will be cached.
+COPY ./requirements /requirements
+
+# install python dependencies
+RUN pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/local.txt \
+    && rm -rf /requirements
 
 
 
 # Python 'run' stage
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-buster as python-run-stage
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -1,28 +1,60 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-buster as docs-build-stage
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apt-get update \
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
     # dependencies for building Python packages
-    && apt-get install -y build-essential \
+    build-essential \
     # psycopg2 dependencies
-    && apt-get install -y libpq-dev \
+    libpq-dev \
     # Translations dependencies
-    && apt-get install -y gettext \
+    gettext \
     # Uncomment below lines to enable Sphinx output to latex and pdf
-    # && apt-get install -y texlive-latex-recommended \
-    # && apt-get install -y texlive-fonts-recommended \
-    # && apt-get install -y texlive-latex-extra \
-    # && apt-get install -y latexmk \
+    # texlive-latex-recommended \
+    # texlive-fonts-recommended \
+    # texlive-latex-extra \
+    # latexmk \
     # cleaning up unused files
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/*
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
-# All imports needed for autodoc.
-RUN pip install -r /requirements/local.txt -r /requirements/production.txt
+
+# install python dependencies
+RUN pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/local.txt -r /requirements/production.txt \
+    && rm -rf /requirements
+
+
+FROM python:3.8-slim-buster as docs-run-stage
+
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    # dependencies for building Python packages
+    build-essential \
+    # psycopg2 dependencies
+    libpq-dev \
+    # Translations dependencies
+    gettext \
+    # Uncomment below lines to enable Sphinx output to latex and pdf
+    # texlive-latex-recommended \
+    # texlive-fonts-recommended \
+    # texlive-latex-extra \
+    # latexmk \
+    # cleaning up unused files
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# copy python dependencies from python-build-stage
+COPY --from=docs-build-stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
+COPY --from=docs-build-stage /usr/local/bin/ /usr/local/bin/
+
 
 WORKDIR /docs
 

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -13,9 +13,6 @@ RUN npm run build
 FROM python:3.8-slim-buster as python-build-stage
 ENV PYTHONDONTWRITEBYTECODE 1
 
-# Requirements are installed here to ensure they will be cached.
-COPY ./requirements /requirements
-
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
@@ -25,14 +22,17 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   gettext \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/* \
-  # install python dependencies
-  && pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/production.txt \
-  && rm -rf /requirements
+  && rm -rf /var/lib/apt/lists/*
 
+# Requirements are installed here to ensure they will be cached.
+COPY ./requirements /requirements
+
+# install python dependencies
+Run pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/production.txt \
+    && rm -rf /requirements
 
 # Python 'run' stage
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-buster as python-run-stage
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -78,8 +78,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 
 # copy python dependencies from python-build-stage
-COPY --from=build_stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
-COPY --from=build_stage /usr/local/bin/ /usr/local/bin/
+COPY --from=python-build-stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
+COPY --from=python-build-stage /usr/local/bin/ /usr/local/bin/
 
 {%- if cookiecutter.js_task_runner == 'Gulp' %}
 COPY --from=client-builder --chown=django:django /app /app

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -11,7 +11,7 @@ RUN npm run build
 
 # Python build stage
 FROM python:3.8-slim-buster as python-build-stage
-
+ENV PYTHONDONTWRITEBYTECODE 1
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
@@ -26,14 +26,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/* \
-  # create python dependency wheels
-  && pip wheel --no-cache-dir --no-deps --use-feature=2020-resolver --wheel-dir /usr/src/app/wheels -r /requirements/production.txt \
+  # install python dependencies
+  && pip install --no-cache-dir --use-feature=2020-resolver -r /requirements/production.txt \
   && rm -rf /requirements
 
 
 # Python 'run' stage
 FROM python:3.8-slim-buster
 
+ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 RUN addgroup --system django \
@@ -76,11 +77,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && rm -rf /var/lib/apt/lists/*
 
 
-# copy python dependency wheels from python-build-stage
-COPY --from=python-build-stage /usr/src/app/wheels /wheels
-
-# install python dependencies
-RUN pip install --no-cache /wheels/*
+# copy python dependencies from python-build-stage
+COPY --from=build_stage /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
+COPY --from=build_stage /usr/local/bin/ /usr/local/bin/
 
 {%- if cookiecutter.js_task_runner == 'Gulp' %}
 COPY --from=client-builder --chown=django:django /app /app

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -7,30 +7,37 @@ RUN npm install && npm cache clean --force
 COPY . /app
 RUN npm run build
 
-# Python build stage
 {%- endif %}
+
+# Python build stage
+FROM python:3.8-slim-buster as python-build-stage
+
+
+# Requirements are installed here to ensure they will be cached.
+COPY ./requirements /requirements
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  # dependencies for building Python packages
+  build-essential \
+  # psycopg2 dependencies
+  libpq-dev \
+  # Translations dependencies
+  gettext \
+  # cleaning up unused files
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/* \
+  # create python dependency wheels
+  && pip wheel --no-cache-dir --no-deps --use-feature=2020-resolver --wheel-dir /usr/src/app/wheels -r /requirements/production.txt \
+  && rm -rf /requirements
+
+
+# Python 'run' stage
 FROM python:3.8-slim-buster
 
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update \
-  # dependencies for building Python packages
-  && apt-get install -y build-essential \
-  # psycopg2 dependencies
-  && apt-get install -y libpq-dev \
-  # Translations dependencies
-  && apt-get install -y gettext \
-  # cleaning up unused files
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/*
-
 RUN addgroup --system django \
     && adduser --system --ingroup django django
-
-# Requirements are installed here to ensure they will be cached.
-COPY ./requirements /requirements
-RUN pip install --no-cache-dir -r /requirements/production.txt \
-    && rm -rf /requirements
 
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
@@ -57,6 +64,23 @@ COPY ./compose/production/django/celery/flower/start /start-flower
 RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 {%- endif %}
+
+# installing required system dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  # psycopg2 dependencies
+  libpq-dev \
+  # Translations dependencies
+  gettext \
+  # cleaning up unused files
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/*
+
+
+# copy python dependency wheels from python-build-stage
+COPY --from=python-build-stage /usr/src/app/wheels /wheels
+
+# install python dependencies
+RUN pip install --no-cache /wheels/*
 
 {%- if cookiecutter.js_task_runner == 'Gulp' %}
 COPY --from=client-builder --chown=django:django /app /app

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:v2.2.11
+FROM traefik:v2.0
 RUN mkdir -p /etc/traefik/acme \
   && touch /etc/traefik/acme/acme.json \
   && chmod 600 /etc/traefik/acme/acme.json

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:v2.0
+FROM traefik:v2.2.11
 RUN mkdir -p /etc/traefik/acme \
   && touch /etc/traefik/acme/acme.json \
   && chmod 600 /etc/traefik/acme/acme.json


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->
I am proposing to use multi-stage builds for building the python part of Docs.

This can be done by installing all required OS and python dependencies and then to just copy over those files to the run stage. This would cause a nearly 35-40% reduction in size!


Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Smaller images are highly desirable because they would greatly reduce the time of re-deployment and deployment of containers and would also save a lot of time and money especially bandwidth costs.