### PR TITLE
Centered the messages div in the base.html template.

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -80,7 +80,7 @@
 
       {% if messages %}
           {% for message in messages %}
-              <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}">{{ message }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+              <div align="center" class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}">{{ message }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
           {% endfor %}
       {% endif %}
 


### PR DESCRIPTION
## Description

The base.html alert div should be centered so as to render the message in the middle.

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The default setting aligns the rendered message completely to the left. I believe this looks ungainly and should be rectified so as to maintain a symmetrical amount of padding on each side.

## Testing concerns

This is a small cosmetic change falling under the purview of front end testing, which to my understanding is not present within this project's testing structure.

## Separation of concerns

In the event of this pull request being accepted, concerns might be raised about implanting CSS within HTML tags. This change might also be implemented in the project's default CSS file, within the static directory.

## Demonstration

![messages_before_after](https://user-images.githubusercontent.com/51290353/93387484-9992a300-f869-11ea-89a1-7aea8a3d193c.gif)

