### PR TITLE
Auto merge Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: pip
+    directory: "/{{ cookiecutter.project_slug }}/requirements"
+    schedule:
+      interval: daily

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,27 @@
+name: "Dependabot Automerge - Action"
+
+on:
+  pull_request:
+
+jobs:
+  worker:
+    runs-on: ubuntu-latest
+
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: automerge
+        uses: actions/github-script@0.2.0
+        with:
+          script: |
+            github.pullRequests.createReview({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE'
+            })
+            github.pullRequests.merge({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number
+            })
+          github-token: ${{github.token}}


### PR DESCRIPTION
## Description

Fixes #2852 Adds auto-merging pip updates to this repository using dependabot to alleviate @browniebroke 's workload.

## Rationale

Make updating this repository less stressful. You can view the test repository here: https://github.com/Andrew-Chen-Wang/test-dependabot-automerge You can see that, when one update happens, the rest of the PRs close and are superseded with a new PR, as shown here: https://github.com/Andrew-Chen-Wang/test-dependabot-automerge/pull/3#issuecomment-701741950

This also means we don't need pyup anymore, especially since dependabot covers everything pyup does and auto merges and rebases in case of new updates to the PR.

---

Note: when GitHub acquired dependabot, they disabled the auto merge feature [natively for security reasons](https://github.com/dependabot/dependabot-core/issues/1973#issuecomment-640918321), so that's why I had to create the GitHub action. I took the GitHub action from a Medium post, but I just can't find the blog anymore......

AH! Here it is: https://medium.com/@toufik.airane/automerge-github-dependabot-alerts-with-github-actions-7cd6f5763750