### PR TITLE
Adding celery broker URL

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -17,6 +17,9 @@ import django
 {% if cookiecutter.use_docker == 'y' %}
 sys.path.insert(0, os.path.abspath("/app"))
 os.environ.setdefault("DATABASE_URL", "")
+{% if cookiecutter.use_celery == 'y' -%}
+os.environ.setdefault("CELERY_BROKER_URL", "")
+{%- endif %}
 {% else %}
 sys.path.insert(0, os.path.abspath(".."))
 {%- endif %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

The current version of the docs will not load (local or docker) due to CELERY_BROKER_URL missing from the config.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The docs will not load successfully when you have a celery broker set up (whether it's docker or local) due to the missing config file.  I've added this line to ensure that they do (happy to add tests)

