### PR TITLE
Add dedicated websockets package

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -25,6 +25,7 @@ flower==0.9.5  # https://github.com/mher/flower
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
 uvicorn==0.12.1  # https://github.com/encode/uvicorn
+wsproto==0.15.0  # https://github.com/python-hyper/wsproto/
 {%- endif %}
 
 # Django


### PR DESCRIPTION
## Description

Ref: https://github.com/encode/uvicorn/issues/797

There used to be a package automatically installed; not anymore I guess. This came from a separate package and not cookiecutter-django, but the installation was similar.

## Rationale

For websockets to work, you need a package like wsproto or websockets (which is not as maintained). Uvicorn at some point might have dropped the auto installation of one of these packages that made websockets unavailable to work with.