### PR TITLE
Upgrade factory-boy to 3.1.0

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -37,7 +37,7 @@ pre-commit==2.8.2  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
-factory-boy==3.0.1  # https://github.com/FactoryBoy/factory_boy
+factory-boy==3.1.0  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==3.1.1  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.0.9  # https://github.com/django-extensions/django-extensions

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -23,7 +23,7 @@ class UserFactory(DjangoModelFactory):
                 digits=True,
                 upper_case=True,
                 lower_case=True,
-            ).generate(extra_kwargs={})
+            ).generate(params={"locale": None})
         )
         self.set_password(password)
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

I've upgraded `factory-boy` to version `3.1.0` and updated the `tests.factories.UserFactory` to work with the new version. `factory.Faker.generate` signature has been modified in version 3.1.0; it no longer accepts an `extra_kwargs` argument, instead requires a `params` argument ([associated PR])(https://github.com/FactoryBoy/factory_boy/commit/f0a4ef008f07f8d42221565d8c33b88083f0be6d). The signature of the generate method is private ([discussed here](https://github.com/FactoryBoy/factory_boy/issues/790)), so looks like this should be fixed in downstream packages.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

