### PR TITLE
Fix after uvicorn 0.12.0 - Ship extra dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -24,7 +24,7 @@ flower==0.9.5  # https://github.com/mher/flower
 {%- endif %}
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
-uvicorn==0.12.2  # https://github.com/encode/uvicorn
+uvicorn[standard]==0.12.2  # https://github.com/encode/uvicorn
 wsproto==0.15.0  # https://github.com/python-hyper/wsproto/
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -25,7 +25,6 @@ flower==0.9.5  # https://github.com/mher/flower
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
 uvicorn[standard]==0.12.2  # https://github.com/encode/uvicorn
-wsproto==0.15.0  # https://github.com/python-hyper/wsproto/
 {%- endif %}
 
 # Django


### PR DESCRIPTION
Uvicorn no longer ships extra dependencies uvloop, websockets and httptools as default. To install these dependencies use uvicorn[standard].
cf https://github.com/encode/uvicorn/blob/master/CHANGELOG.md

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Fixes #2915 