### PR TITLE
Add test for UserUpdateView.form_valid()

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -61,7 +61,11 @@ class TestUserUpdateView:
         form.cleaned_data = []
         view.form_valid(form)
 
-        assert messages.get_messages(request)._queued_messages[0].message == "Information successfully updated"
+        found_message = False
+        for message in messages.get_messages(request):
+            assert message.message == "Information successfully updated"
+            found_message = True
+        assert found_message
 
 
 class TestUserRedirectView:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -1,8 +1,12 @@
 import pytest
+from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.http.response import Http404
 from django.test import RequestFactory
 
+from {{ cookiecutter.project_slug }}.users.forms import UserChangeForm
 from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
 from {{ cookiecutter.project_slug }}.users.views import (
@@ -40,6 +44,24 @@ class TestUserUpdateView:
         view.request = request
 
         assert view.get_object() == user
+
+    def test_form_valid(self, user: User, rf: RequestFactory):
+        view = UserUpdateView()
+        request = rf.get("/fake-url/")
+
+        # Add the session/message middleware to the request
+        SessionMiddleware().process_request(request)
+        MessageMiddleware().process_request(request)
+        request.user = user
+
+        view.request = request
+
+        # Initialize the form
+        form = UserChangeForm()
+        form.cleaned_data = []
+        view.form_valid(form)
+
+        assert messages.get_messages(request)._queued_messages[0].message == "Information successfully updated"
 
 
 class TestUserRedirectView:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -31,7 +31,7 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
 
     def form_valid(self, form):
         messages.add_message(
-            self.request, messages.INFO, _("Infos successfully updated")
+            self.request, messages.INFO, _("Information successfully updated")
         )
         return super().form_valid(form)
 


### PR DESCRIPTION

## Description

This implements a simple test for UserUpdateView.form_valid() in the `users` app to ensure that the message this method seeks to add to the request gets added.

This also updates the message itself to correct a typo.

Checklist:

- [X] ~I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)~ Not applicable for this change
- [X] I've updated the documentation or confirm that my change doesn't require any updates


## Rationale

There was exactly one missing test case per coverage coming from the stock install of cookiecutter-django in my app. This tests that one missing case.
