### PR TITLE
Fix CVE-2018-1281

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -208,17 +208,17 @@ Increasingly it is becoming necessary to develop software in a secure environmen
 On order to create a secure environment, we need to have a trusted SSL certficate installed in our Docker application.
 
 #.  **Let's Encrypt**
-    
-    The official line from Let’s Encrypt is: 
 
-    [For local development section] ... The best option: Generate your own certificate, either self-signed or signed by a local root, and trust it in your operating system’s trust store. Then use that certificate in your local web server. See below for details. 
+    The official line from Let’s Encrypt is:
+
+    [For local development section] ... The best option: Generate your own certificate, either self-signed or signed by a local root, and trust it in your operating system’s trust store. Then use that certificate in your local web server. See below for details.
 
     See `letsencrypt.org - certificates-for-localhost`_
 
     .. _`letsencrypt.org - certificates-for-localhost`: https://letsencrypt.org/docs/certificates-for-localhost/
 
 #.  **mkcert: Valid Https Certificates For Localhost**
-    
+
     `mkcert`_ is a simple by design tool that hides all the arcane knowledge required to generate valid TLS certificates. It works for any hostname or IP, including localhost. It supports macOS, Linux, and Windows, and Firefox, Chrome and Java. It even works on mobile devices with a couple manual steps.
 
     See https://blog.filippo.io/mkcert-valid-https-certificates-for-localhost/
@@ -253,11 +253,11 @@ local.yml
       restart: always
       depends_on:
         - django
-    
+
     ...
 
 #. Link the ``nginx-proxy`` to ``django`` through environmental variables.
-   
+
    ``django`` already has an ``.env`` file connected to it. Add the following variables. You should do this especially if you are working with a team and you want to keep your local environment details to yourself.
 
    ::
@@ -274,7 +274,7 @@ config/settings/local.py
 
 You should allow the new hostname. ::
 
-  ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "my-dev-env.local"]
+  ALLOWED_HOSTS = ["localhost", "127.0.0.1", "my-dev-env.local"]
 
 Rebuild your ``docker`` application. ::
 

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -76,11 +76,11 @@ First things first.
 
 #. If you're running synchronously, see the application being served through Django development server: ::
 
-    $ python manage.py runserver 0.0.0.0:8000
+    $ python manage.py runserver 127.0.0.1:8000
 
 or if you're running asynchronously: ::
 
-    $ uvicorn config.asgi:application --host 0.0.0.0 --reload
+    $ uvicorn config.asgi:application --host 127.0.0.1 --reload
 
 .. _PostgreSQL: https://www.postgresql.org/download/
 .. _Redis: https://redis.io/download

--- a/{{cookiecutter.project_slug}}/compose/local/django/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/start
@@ -7,7 +7,7 @@ set -o nounset
 
 python manage.py migrate
 {%- if cookiecutter.use_async == 'y' %}
-uvicorn config.asgi:application --host 0.0.0.0 --reload
+uvicorn config.asgi:application --host 127.0.0.1 --reload
 {%- else %}
-python manage.py runserver_plus 0.0.0.0:8000
+python manage.py runserver_plus 127.0.0.1:8000
 {% endif %}

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -28,7 +28,7 @@ if compress_enabled; then
 fi
 {%- endif %}
 {% if cookiecutter.use_async == 'y' %}
-/usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
+/usr/local/bin/gunicorn config.asgi --bind 127.0.0.1:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
 {% else %}
-/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app
+/usr/local/bin/gunicorn config.wsgi --bind 127.0.0.1:5000 --chdir=/app
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -11,7 +11,7 @@ SECRET_KEY = env(
     default="!!!SET DJANGO_SECRET_KEY!!!",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 # CACHES
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= 
+SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build -c .
 SOURCEDIR     = .
 BUILDDIR      = ./_build
@@ -21,9 +21,9 @@ help:
 
 # Build, watch and serve docs with live reload
 livehtml:
-	sphinx-autobuild -b html 
-	{%- if cookiecutter.use_docker == 'y' %} --host 0.0.0.0
-	{%- else %} --open-browser 
+	sphinx-autobuild -b html
+	{%- if cookiecutter.use_docker == 'y' %} --host 127.0.0.1
+	{%- else %} --open-browser
 	{%- endif %} --port 7000 --watch $(APP) -c . $(SOURCEDIR) $(BUILDDIR)/html
 
 # Outputs rst files from django application code

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -40,10 +40,10 @@ services:
     volumes:
       - production_traefik:/etc/traefik/acme:z
     ports:
-      - "0.0.0.0:80:80"
-      - "0.0.0.0:443:443"
+      - "80:80"
+      - "443:443"
       {%- if cookiecutter.use_celery == 'y' %}
-      - "0.0.0.0:5555:5555"
+      - "5555:5555"
       {%- endif %}
 
   redis:


### PR DESCRIPTION
References:
- https://nvd.nist.gov/vuln/detail/CVE-2018-1281
- https://bandit.readthedocs.io/en/latest/plugins/b104_hardcoded_bind_all_interfaces.html

```
Test results:
>> Issue: [B104:hardcoded_bind_all_interfaces] Possible binding to all interfaces.
   Severity: Medium   Confidence: Medium
   Location: ../local.py:4
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b104_hardcoded_bind_all_interfaces.html
3	# https://docs.djangoproject.com/en/3.1/ref/settings/#allowed-hosts
4	ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
5
```

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] ~~I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)~~ Not applicable
- [x] ~~I've updated the documentation or confirm that my change doesn't require any updates~~ Not applicable

## Rationale

Ensure that allowed host doesn't include a non-routable meta-address.

