### PR TITLE
`pip install cookiecutter` was missing

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -24,7 +24,7 @@ First things first.
 
     $ source <virtual env path>/bin/activate
 
-#. Install cookiecutter and cookiecutter--django: ::
+#. Install cookiecutter and cookiecutter-django: ::
 
     $ pip install cookiecutter
     $ cookiecutter gh:pydanny/cookiecutter-django

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -24,8 +24,9 @@ First things first.
 
     $ source <virtual env path>/bin/activate
 
-#. Install cookiecutter-django: ::
+#. Install cookiecutter and cookiecutter--django: ::
 
+    $ pip install cookiecutter
     $ cookiecutter gh:pydanny/cookiecutter-django
 
 #. Install development requirements: ::


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
