### PR TITLE
Sentry Redis integration enabled by default in production.

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -7,6 +7,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 {%- if cookiecutter.use_celery == 'y' %}
 from sentry_sdk.integrations.celery import CeleryIntegration
 {% endif %}
+from sentry_sdk.integrations.redis import RedisIntegration
 
 {% endif -%}
 from .base import *  # noqa
@@ -351,9 +352,9 @@ sentry_logging = LoggingIntegration(
 )
 
 {%- if cookiecutter.use_celery == 'y' %}
-integrations = [sentry_logging, DjangoIntegration(), CeleryIntegration()]
+integrations = [sentry_logging, DjangoIntegration(), CeleryIntegration(), RedisIntegration()]
 {% else %}
-integrations = [sentry_logging, DjangoIntegration()]
+integrations = [sentry_logging, DjangoIntegration(), RedisIntegration()]
 {% endif -%}
 
 sentry_sdk.init(


### PR DESCRIPTION
## Description
Enables Redis Sentry integration by default.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Redis is the default so Sentry can have its Redis integration enabled by default in the production settings.
