### PR TITLE
Use exception var in status code pages if available

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403.html
@@ -5,5 +5,5 @@
 {% block content %}
 <h1>Forbidden (403)</h1>
 
-<p>{% if exception %}{{ exception }}{% else %}CSRF verification failed. Request aborted.{% endif %}</p>
+<p>{% if exception %}{{ exception }}{% else %}You're not allowed to access this page.{% endif %}</p>
 {% endblock content %}{% endraw %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403.html
@@ -5,5 +5,5 @@
 {% block content %}
 <h1>Forbidden (403)</h1>
 
-<p>CSRF verification failed. Request aborted.</p>
+<p>{% if exception %}{{ exception }}{% else %}CSRF verification failed. Request aborted.{% endif %}</p>
 {% endblock content %}{% endraw %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/404.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/404.html
@@ -5,5 +5,5 @@
 {% block content %}
 <h1>Page not found</h1>
 
-<p>This is not the page you were looking for.</p>
+<p>{% if exception %}{{ exception }}{% else %}This is not the page you were looking for.{% endif %}</p>
 {% endblock content %}{% endraw %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

When you raise PermissionDenied or Http404, you can pass an exception string. Having that output would be nice: https://docs.djangoproject.com/en/dev/ref/views/#the-403-http-forbidden-view