### PR TITLE
Update admin to ignore *_name User attributes

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 
 from {{ cookiecutter.project_slug }}.users.forms import UserChangeForm, UserCreationForm
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -12,8 +12,22 @@ class UserAdmin(auth_admin.UserAdmin):
 
     form = UserChangeForm
     add_form = UserCreationForm
-    fieldsets = (("User", {"fields": ("name",)}),) + tuple(
-        auth_admin.UserAdmin.fieldsets
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        (_("Personal info"), {"fields": ("name", "email")}),
+        (
+            _("Permissions"),
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
+            },
+        ),
+        (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
     list_display = ["username", "name", "is_superuser"]
     search_fields = ["name"]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_admin.py
@@ -1,0 +1,40 @@
+import pytest
+from django.urls import reverse
+
+from {{ cookiecutter.project_slug }}.users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+class TestUserAdmin:
+    def test_changelist(self, admin_client):
+        url = reverse("admin:users_user_changelist")
+        response = admin_client.get(url)
+        assert response.status_code == 200
+
+    def test_search(self, admin_client):
+        url = reverse("admin:users_user_changelist")
+        response = admin_client.get(url, data={"q": "test"})
+        assert response.status_code == 200
+
+    def test_add(self, admin_client):
+        url = reverse("admin:users_user_add")
+        response = admin_client.get(url)
+        assert response.status_code == 200
+
+        response = admin_client.post(
+            url,
+            data={
+                "username": "test",
+                "password1": "My_R@ndom-P@ssw0rd",
+                "password2": "My_R@ndom-P@ssw0rd",
+            },
+        )
+        assert response.status_code == 302
+        assert User.objects.filter(username="test").exists()
+
+    def test_view_user(self, admin_client):
+        user = User.objects.first()
+        url = reverse("admin:users_user_change", kwargs={"object_id": user.pk})
+        response = admin_client.get(url)
+        assert response.status_code == 200

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_admin.py
@@ -34,7 +34,7 @@ class TestUserAdmin:
         assert User.objects.filter(username="test").exists()
 
     def test_view_user(self, admin_client):
-        user = User.objects.first()
+        user = User.objects.get(username="admin")
         url = reverse("admin:users_user_change", kwargs={"object_id": user.pk})
         response = admin_client.get(url)
         assert response.status_code == 200


### PR DESCRIPTION
## Description

Fixes #3016. Do not merge until this has been verified by @leopolicastro also @leopolicastro can you verify this PR works as intended?

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

User model errors on admin
