### PR TITLE
Using SuccessMessageMixin to send success message to django template

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -29,7 +29,7 @@ class UserUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
 
     def get_object(self):
         return self.request.user
-        
+
 
 user_update_view = UserUpdateView.as_view()
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -1,6 +1,6 @@
-from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, RedirectView, UpdateView
@@ -18,23 +18,18 @@ class UserDetailView(LoginRequiredMixin, DetailView):
 user_detail_view = UserDetailView.as_view()
 
 
-class UserUpdateView(LoginRequiredMixin, UpdateView):
+class UserUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
 
     model = User
     fields = ["name"]
+    success_message = _("Information successfully updated")
 
     def get_success_url(self):
         return reverse("users:detail", kwargs={"username": self.request.user.username})
 
     def get_object(self):
         return self.request.user
-
-    def form_valid(self, form):
-        messages.add_message(
-            self.request, messages.INFO, _("Information successfully updated")
-        )
-        return super().form_valid(form)
-
+        
 
 user_update_view = UserUpdateView.as_view()
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

This is a super simple fix taking advantage of the Django built-in SuccessMessageMixin to pass the success message attribute to the template. 

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

 form_valid() at `users/views.py` currently is being overridden only to pass the success message to the template. Therefore, it's better and easier to simply use what Django already provides: [SuccessMessageMixin](https://docs.djangoproject.com/en/3.1/ref/contrib/messages/#django.contrib.messages.views.SuccessMessageMixin)

The code is also easier to understand.
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
