### PR TITLE
Adding local celery instructions to developing-locally

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -143,6 +143,10 @@ when developing locally. If you have the appropriate setup on your local machine
 in ``config/settings/local.py``::
 
     CELERY_TASK_ALWAYS_EAGER = False
+    
+To run Celery locally, make sure redis-server is installed (instructions are available at https://redis.io/topics/quickstart), run the server in one terminal with `redis-server`, and then start celery in another terminal with the following command::
+    
+    celery -A config.celery_app worker --loglevel=info
 
 
 Sass Compilation & Live Reloading


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Updating documentation to make running celery locally easier.

Checklist:

- [x ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I personally spent a lot of time and tabs trying to find this answer, and thought I could save others time with this small addition.
