### PR TITLE
Removed Redundant test_case_sensitivity() and made test_not_authenticated() get the LOGIN_URL dynamically.

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -1,10 +1,12 @@
 import pytest
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http.response import Http404
 from django.test import RequestFactory
+from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.forms import UserChangeForm
 from {{ cookiecutter.project_slug }}.users.models import User
@@ -90,13 +92,7 @@ class TestUserDetailView:
         request.user = AnonymousUser()
 
         response = user_detail_view(request, username=user.username)
+        login_url = reverse(settings.LOGIN_URL)
 
         assert response.status_code == 302
-        assert response.url == "/accounts/login/?next=/fake-url/"
-
-    def test_case_sensitivity(self, rf: RequestFactory):
-        request = rf.get("/fake-url/")
-        request.user = UserFactory(username="UserName")
-
-        with pytest.raises(Http404):
-            user_detail_view(request, username="username")
+        assert response.url == f"{login_url}?next=/fake-url/"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -4,7 +4,6 @@ from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.http.response import Http404
 from django.test import RequestFactory
 from django.urls import reverse
 


### PR DESCRIPTION
## Description

<!-- What's it you're proposing? -->

1) Remove the test, ```test_case_sensitivity()```, which checks if the User model field, username, is case sensitive. It is redundant because **Django User model username field is case-sensitive by default**.

2) The Login URL in the test, test_not_authenticated(), should be fetched dynamically. Currently, it is hard-coded to ```/accounts/login/``` which would break if ```settings.LOGIN_URL``` is modified in ```config.settings.base``` file. 


Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

1) This is just redundant and doesn't provide any advantage and hence should be removed.
2) This change would make the test more resilient to different user-specific configurations as wel.