### PR TITLE
Lint with pre-commit on CI with Github actions

### DIFF
--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -234,7 +234,7 @@ def test_gitlab_invokes_flake8_and_pytest(
         ("y", "docker-compose -f local.yml exec -T django pytest"),
     ],
 )
-def test_github_invokes_flake8_and_pytest(
+def test_github_invokes_linter_and_pytest(
     cookies, context, use_docker, expected_test_script
 ):
     context.update({"ci_tool": "Github", "use_docker": use_docker})
@@ -248,11 +248,11 @@ def test_github_invokes_flake8_and_pytest(
     with open(f"{result.project}/.github/workflows/ci.yml", "r") as github_yml:
         try:
             github_config = yaml.safe_load(github_yml)
-            flake8_present = False
-            for action_step in github_config["jobs"]["flake8"]["steps"]:
-                if action_step.get("run") == "flake8":
-                    flake8_present = True
-            assert flake8_present
+            linter_present = False
+            for action_step in github_config["jobs"]["linter"]["steps"]:
+                if action_step.get("run") == "linter":
+                    linter_present = True
+            assert linter_present
 
             expected_test_script_present = False
             for action_step in github_config["jobs"]["pytest"]["steps"]:

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -250,7 +250,7 @@ def test_github_invokes_linter_and_pytest(
             github_config = yaml.safe_load(github_yml)
             linter_present = False
             for action_step in github_config["jobs"]["linter"]["steps"]:
-                if action_step.get("run") == "linter":
+                if action_step.get("uses", "NA").startswith("pre-commit"):
                     linter_present = True
             assert linter_present
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 
 jobs:
-  flake8:
+  linter:
     runs-on: ubuntu-latest
     steps:
 
@@ -28,13 +28,13 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install flake8
+      - name: Install flake8, flake8-isort, and black
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install flake8 flake8-isort black
 
-      - name: Lint with flake8
-        run: flake8
+      - name: Install and Run Pre-commit 
+        uses: pre-commit/action@v2.0.0
 
 # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 flake8-isort black
 
+      # Run all pre-commit hooks on all the files.
+      # Getting only staged files can be tricky in case a new PR is opened
+      # since the action is run on a branch in detached head state
       - name: Install and Run Pre-commit 
         uses: pre-commit/action@v2.0.0
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install flake8, flake8-isort, and black
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 flake8-isort black
-
       # Run all pre-commit hooks on all the files.
       # Getting only staged files can be tricky in case a new PR is opened
       # since the action is run on a branch in detached head state


### PR DESCRIPTION
## Description

Updated GitHub `ci.yml` file to run pre-commit hooks on all files instead of manually installing and running flake8.

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
A more DRY way of running code-quality tools would be to add them all in the `.pre-commit-config.yaml` file and then invoke pre-commit in CICD. This has a couple of benefits:

```
1) 1 central place for all code quality tools
2) No discrepancy on code quality tools that run in CICD versus on one's local dev env.
```