### PR TITLE
Updated test_urls.py and views.py to re-use User.get_absolute_url()

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
@@ -7,10 +7,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_detail(user: User):
-    assert (
-        reverse("users:detail", kwargs={"username": user.username})
-        == f"/users/{user.username}/"
-    )
+    assert user.get_absolute_url() == f"/users/{user.username}/"
     assert resolve(f"/users/{user.username}/").view_name == "users:detail"
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
@@ -7,7 +7,10 @@ pytestmark = pytest.mark.django_db
 
 
 def test_detail(user: User):
-    assert user.get_absolute_url() == f"/users/{user.username}/"
+    assert (
+        reverse("users:detail", kwargs={"username": user.username})
+        == f"/users/{user.username}/"
+    )
     assert resolve(f"/users/{user.username}/").view_name == "users:detail"
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -25,7 +25,7 @@ class UserUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     success_message = _("Information successfully updated")
 
     def get_success_url(self):
-        return reverse("users:detail", kwargs={"username": self.request.user.username})
+        return self.request.user.get_absolute_url()  # type: ignore [union-attr]
 
     def get_object(self):
         return self.request.user


### PR DESCRIPTION
## Description

Re-use ` User.get_absolute_url()` method to fetch the detail view URL instead of doing `reverse("users:detail", kwargs={"username": user.username})`
Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

This would make the project "DRYer"