### PR TITLE
Refactored test_views.py to not use unnecessary fake_url and made tes…

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -77,13 +77,11 @@ class TestUserUpdateView:
         UserUpdateView.as_view()(request)
 
         # Get the updated user by name
-        updated_user = get_user_model().objects.filter(
-            name=self.form_data["name"]
-        )
+        new_user = get_user_model().objects.filter(name=self.form_data["name"])
 
         # assert that the name matches
-        assert updated_user != []
-        assert updated_user.first().name == self.form_data["name"]  # type: ignore [union-attr]
+        assert new_user != []
+        assert new_user.first().name == self.form_data["name"]  # type: ignore [union-attr]
 
         messages_sent = [m.message for m in messages.get_messages(request)]
         assert messages_sent == [_("Information successfully updated")]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -28,6 +28,8 @@ class TestUserUpdateView:
         https://github.com/pytest-dev/pytest-django/pull/258
     """
 
+    form_data = {"name": "Updated Name"}
+
     def test_get_success_url(self, user: User, rf: RequestFactory):
         url = reverse("users:update")
         request = rf.post(url, self.form_data)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -58,7 +58,7 @@ class TestUserUpdateView:
         # Process request and get response
         response = UserUpdateView.as_view()(request)
 
-        assert response.context_data["object"] == user
+        assert response.context_data["object"] == user  # type: ignore [attr-defined]
 
     def test_form_valid(self, user: User, rf: RequestFactory):
         url = reverse("users:update")
@@ -83,7 +83,7 @@ class TestUserUpdateView:
 
         # assert that the name matches
         assert updated_user != []
-        assert updated_user.first().name == self.form_data["name"]
+        assert updated_user.first().name == self.form_data["name"]  # type: ignore [union-attr]
 
         messages_sent = [m.message for m in messages.get_messages(request)]
         assert messages_sent == [_("Information successfully updated")]


### PR DESCRIPTION

## Description

Refactor `test_views.py` to remove using `fake-url` since that is unnecessary anyway. And to properly test views especially when `POST` requests are concerned.

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

In my opinion, ``test_views.py`` is not properly written. `rf.post` exists for sending POST requests and much of the same functionality is trying to be achieved using `fake-url` with what I think is a hacky way to write tests.
