### PR TITLE
Add watchman reloader support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -53,6 +53,7 @@
   "use_sentry": "n",
   "use_whitenoise": "n",
   "use_heroku": "n",
+  "use_watchman": "n",
   "ci_tool": [
     "None",
     "Travis",

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -292,3 +292,16 @@ See `https with nginx`_ for more information on this configuration.
 Add ``certs/*`` to the ``.gitignore`` file. This allows the folder to be included in the repo but its contents to be ignored.
 
 *This configuration is for local development environments only. Do not use this for production since you might expose your local* ``rootCA-key.pem``.
+
+(Optional) watchman
+~~~~~~~~~~~~~~~~~~~
+
+`Django runserver`_ can use WatchmanReloader that integrates with watchman_.
+Compared to the default StatReloader, it reduces baseline CPU usage
+significantly.
+
+Watchman is automatically installed in Docker for local use if selected during
+project generation.
+
+  .. _watchman: https://facebook.github.io/watchman/
+  .. _Django runserver: https://docs.djangoproject.com/en/3.1/ref/django-admin/#runserver

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -152,8 +152,8 @@ To run Celery locally, make sure redis-server is installed (instructions are ava
 ~~~~~~~~~~~~~~~~~~~
 
 Django runserver can use WatchmanReloader that integrates with watchman_.
-Compared to the default StatReloader, it reduces baseline CPU usage
-significantly.
+Compared to the default StatReloader, it reduces baseline CPU usage for large
+projects.
 
 If you want to use watchman file watcher locally, you'll need to install it
 manually. Please follow instructions on watchman_ page. The pywatchman version

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -148,6 +148,25 @@ To run Celery locally, make sure redis-server is installed (instructions are ava
     
     celery -A config.celery_app worker --loglevel=info
 
+(Optional) watchman
+~~~~~~~~~~~~~~~~~~~
+
+Django runserver can use WatchmanReloader that integrates with watchman_.
+Compared to the default StatReloader, it reduces baseline CPU usage
+significantly.
+
+If you want to use watchman file watcher locally, you'll need to install it
+manually. Please follow instructions on watchman_ page. The pywatchman version
+on pypi is old, but appears to work. If you want a newer version of pywatchman,
+you'll need to build it manually. To do that clone latest version of watchman
+from GitHub, then::
+
+    git clone --depth 1 https://github.com/facebook/watchman/ && \
+        cd watchman/python && python setup.py bdist_wheel && \
+        pip install dist/pywatchman*whl
+
+.. _watchman: https://facebook.github.io/watchman/
+
 
 Sass Compilation & Live Reloading
 ---------------------------------

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -113,6 +113,11 @@ use_heroku:
     Indicates whether the project should be configured so as to be deployable
     to Heroku_.
 
+use_watchman:
+    Indicates whether to use watchman_ as file watcher. `Django runserver`_ has
+    builtin support for watchman . Adds automatic watchman installation in Docker_,
+    but needs manual installation otherwise.
+
 ci_tool:
     Select a CI tool for running tests. The choices are:
 
@@ -178,3 +183,6 @@ debug:
 .. _GitLab CI: https://docs.gitlab.com/ee/ci/
 
 .. _Github Actions: https://docs.github.com/en/actions
+
+.. _watchman: https://facebook.github.io/watchman/
+.. _Django runserver: https://docs.djangoproject.com/en/3.1/ref/django-admin/#runserver

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -324,6 +324,10 @@ def remove_storages_module():
     os.remove(os.path.join("{{cookiecutter.project_slug}}", "utils", "storages.py"))
 
 
+def remove_watchman_files():
+    os.remove(".watchmanconfig")
+
+
 def main():
     debug = "{{ cookiecutter.debug }}".lower() == "y"
 
@@ -407,6 +411,9 @@ def main():
 
     if "{{ cookiecutter.use_async }}".lower() == "n":
         remove_async_files()
+
+    if "{{ cookiecutter.use_watchman }}".lower() == "n":
+        remove_watchman_files()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -95,7 +95,5 @@ if (
     "{{ cookiecutter.use_async }}".lower() == "y"
     and "{{ cookiecutter.use_watchman }}".lower() == "y"
 ):
-    print(
-        "Async and watchman don't work together "
-    )
+    print("Async and watchman don't work together ")
     sys.exit(1)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -86,6 +86,16 @@ if (
     and "{{ cookiecutter.use_watchman }}".lower() == "y"
 ):
     print(
-        "Automatic watchman installation is only setup in Docker for now. You can install "
-        "watchman from https://github.com/facebook/watchman/releases and pywatchman from pypi."
+        "Automatic watchman installation is only setup in Docker for now. Please see "
+        '"Getting Up and Running Locally" section of cookiecutter-django docs for details '
+        "on local installation"
     )
+
+if (
+    "{{ cookiecutter.use_async }}".lower() == "y"
+    and "{{ cookiecutter.use_watchman }}".lower() == "y"
+):
+    print(
+        "Async and watchman don't work together "
+    )
+    sys.exit(1)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -80,3 +80,12 @@ if (
         "You should either use AWS or select a different Mail Service for sending emails."
     )
     sys.exit(1)
+
+if (
+    "{{ cookiecutter.use_docker }}".lower() == "n"
+    and "{{ cookiecutter.use_watchman }}".lower() == "y"
+):
+    print(
+        "Automatic watchman installation is only setup in Docker for now. You can install "
+        "watchman from https://github.com/facebook/watchman/releases and pywatchman from pypi."
+    )

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -74,7 +74,8 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "GCP", "mail_service": "Other SMTP"},
     # Note: cloud_providers GCP and None with mail_service Amazon SES is not supported
     {"use_async": "y"},
-    {"use_async": "n"},
+    {"use_async": "n", "use_watchman": "y"},
+    {"use_async": "n", "use_watchman": "n"},
     {"use_drf": "y"},
     {"use_drf": "n"},
     {"js_task_runner": "None"},
@@ -93,8 +94,6 @@ SUPPORTED_COMBINATIONS = [
     {"use_whitenoise": "n"},
     {"use_heroku": "y"},
     {"use_heroku": "n"},
-    {"use_watchman": "y"},
-    {"use_watchman": "n"},
     {"ci_tool": "None"},
     {"ci_tool": "Travis"},
     {"ci_tool": "Gitlab"},

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -93,6 +93,8 @@ SUPPORTED_COMBINATIONS = [
     {"use_whitenoise": "n"},
     {"use_heroku": "y"},
     {"use_heroku": "n"},
+    {"use_watchman": "y"},
+    {"use_watchman": "n"},
     {"ci_tool": "None"},
     {"ci_tool": "Travis"},
     {"ci_tool": "Gitlab"},

--- a/{{cookiecutter.project_slug}}/.envs/.local/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.local/.django
@@ -15,3 +15,9 @@ REDIS_URL=redis://redis:6379/0
 CELERY_FLOWER_USER=!!!SET CELERY_FLOWER_USER!!!
 CELERY_FLOWER_PASSWORD=!!!SET CELERY_FLOWER_PASSWORD!!!
 {% endif %}
+
+{%- if cookiecutter.use_watchman == 'y' %}
+# Watchman
+# ------------------------------------------------------------------------------
+DJANGO_WATCHMAN_TIMEOUT=30
+{% endif %}

--- a/{{cookiecutter.project_slug}}/.watchmanconfig
+++ b/{{cookiecutter.project_slug}}/.watchmanconfig
@@ -1,0 +1,13 @@
+{
+  "ignore_dirs": [
+    "node_modules",
+    ".envs",
+    "bin",
+    "lib",
+    "include",
+    ".git",
+    ".idea",
+    "templates",
+    "static_assets"
+  ]
+}

--- a/{{cookiecutter.project_slug}}/.watchmanconfig
+++ b/{{cookiecutter.project_slug}}/.watchmanconfig
@@ -10,5 +10,8 @@
     "templates",
     "static",
     "static_assets"
+    {%-if cookiecutter.use_docker %}
+    "compose"
+    {%- endif %}
   ]
 }

--- a/{{cookiecutter.project_slug}}/.watchmanconfig
+++ b/{{cookiecutter.project_slug}}/.watchmanconfig
@@ -8,6 +8,7 @@
     ".git",
     ".idea",
     "templates",
+    "static",
     "static_assets"
   ]
 }

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -10,9 +10,30 @@ RUN apt-get update \
   && apt-get install -y libpq-dev \
   # Translations dependencies
   && apt-get install -y gettext \
+{%- if cookiecutter.use_watchman == "y" %}
+  # needed to download watchman
+  && apt-get install -y curl unzip subversion \
+{%- endif %}
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
+
+{%- if cookiecutter.use_watchman == "y" %}
+ARG WATCHMAN_VERSION
+WORKDIR /watchman-build
+RUN curl -sSLO https://github.com/facebook/watchman/releases/download/${WATCHMAN_VERSION}/watchman-${WATCHMAN_VERSION}-linux.zip && \
+    unzip watchman-${WATCHMAN_VERSION}-linux.zip && \
+    chmod +x watchman-${WATCHMAN_VERSION}-linux/bin/* \
+      watchman-${WATCHMAN_VERSION}-linux/lib/* && \
+    cp -rp watchman-${WATCHMAN_VERSION}-linux/bin/* /usr/local/bin/ && \
+    cp -rp watchman-${WATCHMAN_VERSION}-linux/lib/* /usr/local/lib/ && \
+    mkdir -p /usr/local/var/run/watchman && chown 2777 /usr/local/var/run/watchman
+# The pywatchman version on pypi is really outdated, build from source
+RUN svn export https://github.com/facebook/watchman/tags/${WATCHMAN_VERSION}/python
+RUN cd python && python setup.py bdist_wheel && pip install dist/pywatchman*whl
+WORKDIR /
+RUN rm -rf /watchman-build
+{%- endif %}
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
   && apt-get install -y gettext \
 {%- if cookiecutter.use_watchman == "y" %}
   # needed to download watchman
-  && apt-get install -y curl unzip git \
+  && apt-get install -y curl unzip \
 {%- endif %}
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
@@ -29,8 +29,10 @@ RUN curl -sSLO https://github.com/facebook/watchman/releases/download/${WATCHMAN
     cp -rp watchman-${WATCHMAN_VERSION}-linux/lib/* /usr/local/lib/ && \
     mkdir -p /usr/local/var/run/watchman && chown 2777 /usr/local/var/run/watchman
 # The pywatchman version on pypi is really outdated, build from source
-RUN git clone --branch ${WATCHMAN_VERSION} --depth 1 https://github.com/facebook/watchman/
-RUN cd watchman/python && python setup.py bdist_wheel && pip install dist/pywatchman*whl
+RUN curl -sSLO https://github.com/facebook/watchman/archive/refs/tags/${WATCHMAN_VERSION}.zip && \
+    unzip ${WATCHMAN_VERSION}.zip && cd watchman-*/python && \
+    python setup.py bdist_wheel && \
+    pip install dist/pywatchman*whl
 WORKDIR /
 RUN rm -rf /watchman-build
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -12,14 +12,14 @@ RUN apt-get update \
   && apt-get install -y gettext \
 {%- if cookiecutter.use_watchman == "y" %}
   # needed to download watchman
-  && apt-get install -y curl unzip subversion \
+  && apt-get install -y curl unzip git \
 {%- endif %}
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 
 {%- if cookiecutter.use_watchman == "y" %}
-ARG WATCHMAN_VERSION
+ARG WATCHMAN_VERSION=v2021.03.01.00
 WORKDIR /watchman-build
 RUN curl -sSLO https://github.com/facebook/watchman/releases/download/${WATCHMAN_VERSION}/watchman-${WATCHMAN_VERSION}-linux.zip && \
     unzip watchman-${WATCHMAN_VERSION}-linux.zip && \
@@ -29,8 +29,8 @@ RUN curl -sSLO https://github.com/facebook/watchman/releases/download/${WATCHMAN
     cp -rp watchman-${WATCHMAN_VERSION}-linux/lib/* /usr/local/lib/ && \
     mkdir -p /usr/local/var/run/watchman && chown 2777 /usr/local/var/run/watchman
 # The pywatchman version on pypi is really outdated, build from source
-RUN svn export https://github.com/facebook/watchman/tags/${WATCHMAN_VERSION}/python
-RUN cd python && python setup.py bdist_wheel && pip install dist/pywatchman*whl
+RUN git clone --branch ${WATCHMAN_VERSION} --depth 1 https://github.com/facebook/watchman/
+RUN cd watchman/python && python setup.py bdist_wheel && pip install dist/pywatchman*whl
 WORKDIR /
 RUN rm -rf /watchman-build
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -9,10 +9,6 @@ services:
     build:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
-      {%- if cookiecutter.use_watchman == 'y' %}
-      args:
-        WATCHMAN_VERSION: v2021.03.01.00
-      {%- endif %}
     image: {{ cookiecutter.project_slug }}_local_django
     container_name: django
     depends_on:

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -9,6 +9,10 @@ services:
     build:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
+      {%- if cookiecutter.use_watchman == 'y' %}
+      args:
+        WATCHMAN_VERSION: v2021.03.01.00
+      {%- endif %}
     image: {{ cookiecutter.project_slug }}_local_django
     container_name: django
     depends_on:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->
Add WatchmanReloader support by installing watchman and pywatchman in Docker. For local development without docker, add hints about installing watchman.

Checklist:

- [ X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The default polling based watcher (StatReloader) adds a decent amount of CPU and IO load for large projects, enough to be noticeable. In my case CPU spikes went from 20% to close to 0.

Watchman is a widely used file watcher and Django runserver has built-in integration.

Fix #3092 
