### PR TITLE
Fix gitlab-ci using duplicate key name for image

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -21,7 +21,6 @@ flake8:
 
 pytest:
   stage: test
-  image: python:3.8
   {% if cookiecutter.use_docker == 'y' -%}
   image: docker/compose:latest
   tags:
@@ -36,6 +35,7 @@ pytest:
   script:
     - docker-compose -f local.yml run django pytest
   {%- else %}
+  image: python:3.8
   tags:
     - python
   services:

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -34,7 +34,7 @@ pytest:
     - docker-compose -f local.yml up -d
   script:
     - docker-compose -f local.yml run django pytest
-  {%- else %}
+  {%- else -%}
   image: python:3.8
   tags:
     - python


### PR DESCRIPTION
## Description

When choosing to use Docker and GitLab, there is a duplicate key value for the image name for pytest.

```
pytest:
  stage: test
  image: python:3.8
  image: docker/compose:latest
```

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option) **I don't see any options in the tests for this.**
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
The duplicate key didn't seem to cause any problems, but it is incorrect.
