### PR TITLE
Removing pycharm docs if app does not use pycharm

### DIFF
--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -282,3 +282,20 @@ def test_error_if_incompatible(cookies, context, invalid_context):
 
     assert result.exit_code != 0
     assert isinstance(result.exception, FailedHookException)
+
+
+@pytest.mark.parametrize(
+    ["use_pycharm", "pycharm_docs_exist"],
+    [
+        ("n", False),
+        ("y", True),
+    ],
+)
+def test_pycharm_docs_removed(cookies, context, use_pycharm, pycharm_docs_exist):
+    """."""
+    context.update({"use_pycharm": use_pycharm})
+    result = cookies.bake(extra_context=context)
+
+    with open(f"{result.project}/docs/index.rst", "r") as f:
+        has_pycharm_docs = 'pycharm/configuration' in f.read()
+        assert has_pycharm_docs == pycharm_docs_exist

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -298,4 +298,4 @@ def test_pycharm_docs_removed(cookies, context, use_pycharm, pycharm_docs_exist)
 
     with open(f"{result.project}/docs/index.rst", "r") as f:
         has_pycharm_docs = "pycharm/configuration" in f.read()
-        assert has_pycharm_docs == pycharm_docs_exist
+        assert has_pycharm_docs is pycharm_docs_exist

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -297,5 +297,5 @@ def test_pycharm_docs_removed(cookies, context, use_pycharm, pycharm_docs_exist)
     result = cookies.bake(extra_context=context)
 
     with open(f"{result.project}/docs/index.rst", "r") as f:
-        has_pycharm_docs = 'pycharm/configuration' in f.read()
+        has_pycharm_docs = "pycharm/configuration" in f.read()
         assert has_pycharm_docs == pycharm_docs_exist

--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -10,8 +10,8 @@ Welcome to {{ cookiecutter.project_name }}'s documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   howto
-   pycharm/configuration
+   howto{% if cookiecutter.use_pycharm == 'y' %}
+   pycharm/configuration{% endif %}
    users
 
 


### PR DESCRIPTION
## Description

Adding templating to only include the pycharm docs in an app if `use_pycharm` is `y`.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates
