### PR TITLE
Fix README link

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -120,6 +120,7 @@ Now you have your own mail server running locally, ready to receive whatever you
 
 .. _`Download the latest MailHog release`: https://github.com/mailhog/MailHog/releases
 {%- endif %}
+
 .. _mailhog: https://github.com/mailhog/MailHog
 {%- endif %}
 {%- if cookiecutter.use_sentry == "y" %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Link to mailhog was broken with Docker addition. https://github.com/Hear-Ye/Hear-Ye-Server 

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix broken link. Take a look here at the Mailhog section: https://github.com/Hear-Ye/Hear-Ye-Server