### PR TITLE
Async don't reload templates + static

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -115,6 +115,12 @@ def remove_async_files():
         os.remove(file_name)
 
 
+def remove_async_docker_files():
+    file_names = [os.path.join("compose", "local", "django", "run.py")]
+    for file_name in file_names:
+        os.remove(file_name)
+
+
 def remove_dottravisyml_file():
     os.remove(".travis.yml")
 
@@ -407,6 +413,8 @@ def main():
 
     if "{{ cookiecutter.use_async }}".lower() == "n":
         remove_async_files()
+        if "{{ cookiecutter.use_docker }}".lower() == "y":
+            remove_async_docker_files()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 

--- a/{{cookiecutter.project_slug}}/compose/local/django/run.py
+++ b/{{cookiecutter.project_slug}}/compose/local/django/run.py
@@ -5,9 +5,26 @@ import uvicorn
 from uvicorn.supervisors.watchgodreload import CustomWatcher
 
 
+ignored = {
+    "templates",
+    "static",
+    "staticfiles",
+    "compose",
+    ".ipython",
+    "bin",
+    ".pytest_cache",
+    ".idea",
+    "media",
+    "htmlcov",
+    "docs",
+    "locale",
+    "requirements",
+}
+
+
 class WatchgodWatcher(CustomWatcher):
     def __init__(self, *args, **kwargs):
-        self.ignored_dirs.update({"templates", "static", "compose"})
+        self.ignored_dirs.update(ignored)
         super(WatchgodWatcher, self).__init__(*args, **kwargs)
 
 

--- a/{{cookiecutter.project_slug}}/compose/local/django/run.py
+++ b/{{cookiecutter.project_slug}}/compose/local/django/run.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+import uvicorn
+from uvicorn.supervisors.watchgodreload import CustomWatcher
+
+
+class WatchgodWatcher(CustomWatcher):
+    def __init__(self, *args, **kwargs):
+        self.ignored_dirs.update({"templates", "static", "compose"})
+        super(WatchgodWatcher, self).__init__(*args, **kwargs)
+
+
+uvicorn.supervisors.watchgodreload.CustomWatcher = WatchgodWatcher
+if __name__ == "__main__":
+    sys.path.insert(0, os.path.abspath("/app"))
+    uvicorn.run("config.asgi:application", host="0.0.0.0", reload=True)

--- a/{{cookiecutter.project_slug}}/compose/local/django/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/start
@@ -7,7 +7,7 @@ set -o nounset
 
 python manage.py migrate
 {%- if cookiecutter.use_async == 'y' %}
-uvicorn config.asgi:application --host 0.0.0.0 --reload
+python compose/local/django/run.py
 {%- else %}
 python manage.py runserver_plus 0.0.0.0:8000
 {% endif %}


### PR DESCRIPTION
## Description

Make async reloading much more efficient by only reloading Python files. No template/static file should be reloaded. Fixes #3093 (doesn't implement what was proposed but the general idea is done)

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Watchgod doesn't need to check HTML, CSS, JS etc. files. Like the Django statreloader, we only need to reload the Python files. These other files are automatically changed because Django is just loading files. This makes fixing HTML, CSS, and JS files much faster to fix since you don't have to wait for the server to finish reloading.