### PR TITLE
Move ARG PYTHON_VERSION=3.9-slim-buster to the global scope

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -1,3 +1,5 @@
+ARG PYTHON_VERSION=3.9-slim-buster
+
 {% if cookiecutter.js_task_runner == 'Gulp' -%}
 FROM node:10-stretch-slim as client-builder
 
@@ -10,8 +12,6 @@ COPY . ${APP_HOME}
 RUN npm run build
 
 {%- endif %}
-
-ARG PYTHON_VERSION=3.9-slim-buster
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} as python


### PR DESCRIPTION
## Description


    
Move ARG PYTHON_VERSION=3.9-slim-buster to the global scope of production Dockerfile to fix #3187.
The #3187 occurs when Gulp is selected as `js_task_runner` on project generation.


Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Since `PYTHON_VERSION` will be reused on the `FROM` clause, then it should be defined on the global scope of the Dockerfile

Docker ARG scope explained: https://github.com/moby/moby/issues/40830#issuecomment-622949605
On the previous link, [@ kkirsche](https://github.com/kkirsche) creates this very useful diagram

![image](https://user-images.githubusercontent.com/807599/118575615-4a38a580-b75d-11eb-8f20-b0ddc09a17e2.png)

