### PR TITLE
Install cookiecutter was missing up to now.

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -24,6 +24,10 @@ First things first.
 
     $ source <virtual env path>/bin/activate
 
+#. Install cookiecutter: ::
+
+    $ pip install cookiecutter
+
 #. Install cookiecutter-django: ::
 
     $ cookiecutter gh:pydanny/cookiecutter-django


### PR DESCRIPTION
## Description

Small change to the docs. Before installing cookiecutter-django you need to install cookiecutter.


