### PR TITLE
Updated .pre-commit-config.yaml to self-update its dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -26,3 +26,10 @@ repos:
       - id: flake8
         args: ['--config=setup.cfg']
         additional_dependencies: [flake8-isort]
+
+
+# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
+ci:
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false


### PR DESCRIPTION
## Description

Pre-commit will ensure its dependencies stay up to date. It will now automatically also run on any raised PRs. This will ensure committed code will always stay consistent.

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

One does no longer need to run `pre-commit autoupdate` to make its pre-commit's dependencies stay up to date. 