### PR TITLE
Shorthand for the officially supported buildpack

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -10,7 +10,7 @@ Run these commands to deploy the project to Heroku:
 
 .. code-block:: bash
 
-    heroku create --buildpack https://github.com/heroku/heroku-buildpack-python
+    heroku create --buildpack heroku/python 
 
     heroku addons:create heroku-postgresql:hobby-dev
     # On Windows use double quotes for the time zone, e.g.


### PR DESCRIPTION
Replacing the Github link with the Heroku shorthand defined for the officially supported buildpack.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Replacing the Github link with the Heroku shorthand defined for the officially supported [buildpack](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-python).

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Opting to use the officially supported short hand as defined in the [official documentation](https://devcenter.heroku.com/articles/buildpacks).
