### PR TITLE
Update gitignore for VSCode

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -159,6 +159,10 @@ typings/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
 
 
 {% if cookiecutter.use_pycharm == 'y' -%}


### PR DESCRIPTION
## Description

Little update for the VSCode section on the gitignore

## Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

[Current GitHub's gitignore for VSCode](https://github.com/github/gitignore/blob/991e760c1c6d50fdda246e0178b9c58b06770b90/Global/VisualStudioCode.gitignore) includes a couple more things.
