### PR TITLE
Wrap jQuery call in `DOMContentLoaded` event listener on account email page

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/account/email.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/account/email.html
@@ -74,7 +74,9 @@ window.addEventListener('DOMContentLoaded',function() {
   }
 });
 
-$('.form-group').removeClass('row');
+document.addEventListener('DOMContentLoaded', function() {
+  $('.form-group').removeClass('row');
+})
 </script>
 {% endblock %}
 {%- endraw %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->
Fix error occurred while loading jQuery with defer and call it but didn't wait for the whole package downloaded.

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
The line `$('.form-group').removeClass('row');` is not executable, because at that moment `$` is not defined,  unless wrap it in DOMContentLoaded
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
