### PR TITLE
Revert "Fix Celery ports error on local Docker"

### DIFF
--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -77,6 +77,7 @@ services:
       {%- if cookiecutter.use_mailhog == 'y' %}
       - mailhog
       {%- endif %}
+    ports: []
     command: /start-celeryworker
 
   celerybeat:
@@ -89,6 +90,7 @@ services:
       {%- if cookiecutter.use_mailhog == 'y' %}
       - mailhog
       {%- endif %}
+    ports: []
     command: /start-celerybeat
 
   flower:


### PR DESCRIPTION
Reverts pydanny/cookiecutter-django#3241 because generates the error `Bind for 0.0.0.0:8000 failed: port is already allocated`.

![image](https://user-images.githubusercontent.com/807599/123633555-bcd28180-d7ef-11eb-8297-334b0d3e7e43.png)


