### PR TITLE
Upgrade to Redis 6

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     services:
       {%- if cookiecutter.use_celery == 'y' %}
       redis:
-        image: redis:5.0
+        image: redis:6.2.4
         ports:
           - 6379:6379
       {%- endif %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     services:
       {%- if cookiecutter.use_celery == 'y' %}
       redis:
-        image: redis:6.2.4
+        image: redis:6
         ports:
           - 6379:6379
       {%- endif %}

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -64,7 +64,7 @@ services:
   {%- if cookiecutter.use_celery == 'y' %}
 
   redis:
-    image: redis:5.0
+    image: redis:6.2.4
     container_name: redis
 
   celeryworker:

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -64,7 +64,7 @@ services:
   {%- if cookiecutter.use_celery == 'y' %}
 
   redis:
-    image: redis:6.2.4
+    image: redis:6
     container_name: redis
 
   celeryworker:

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -47,7 +47,7 @@ services:
       {%- endif %}
 
   redis:
-    image: redis:5.0
+    image: redis:6.2.4
   {%- if cookiecutter.use_celery == 'y' %}
 
   celeryworker:

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -47,7 +47,7 @@ services:
       {%- endif %}
 
   redis:
-    image: redis:6.2.4
+    image: redis:6
   {%- if cookiecutter.use_celery == 'y' %}
 
   celeryworker:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Use Redis 6 instead of 5. I'm not sure if we want to specify such a specific number though. Last I checked, Redis automatically updates itself every time you restart Redis, so maybe we can specify an image like `redis:6`? Thoughts?
<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fixes #2758
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
