### PR TITLE
Define REMAP_SIGTERM=SIGQUIT on Profile of Celery on Heroku

### DIFF
--- a/{{cookiecutter.project_slug}}/Procfile
+++ b/{{cookiecutter.project_slug}}/Procfile
@@ -5,6 +5,6 @@ web: gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker
 web: gunicorn config.wsgi:application
 {%- endif %}
 {%- if cookiecutter.use_celery == "y" -%}
-worker: celery worker --app=config.celery_app --loglevel=info
-beat: celery beat --app=config.celery_app --loglevel=info
+worker: REMAP_SIGTERM=SIGQUIT celery worker --app=config.celery_app --loglevel=info
+beat: REMAP_SIGTERM=SIGQUIT celery beat --app=config.celery_app --loglevel=info
 {%- endif %}


### PR DESCRIPTION


<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

- Define REMAP_SIGTERM=SIGQUIT on Profile of Celery on Heroku
<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Is the expected configuration on Heroku:

https://devcenter.heroku.com/articles/celery-heroku#using-remap_sigterm