### PR TITLE
Moved isort config from `.editorconfig` to `setup.cfg`

### DIFF
--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -12,18 +12,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.py]
-line_length = 88
-known_first_party = {{cookiecutter.project_slug}},config
-multi_line_output = 3
-default_section = THIRDPARTY
-recursive = true
-skip = venv/
-skip_glob = **/migrations/*.py
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-
 [*.{html,css,scss,json,yml}]
 indent_style = space
 indent_size = 2

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -6,6 +6,18 @@ exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
 max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
 
+[isort]
+line_length = 88
+known_first_party = {{cookiecutter.project_slug}},config
+multi_line_output = 3
+default_section = THIRDPARTY
+recursive = true
+skip = venv/
+skip_glob = **/migrations/*.py
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+
 [mypy]
 python_version = 3.9
 check_untyped_defs = True

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -11,7 +11,6 @@ line_length = 88
 known_first_party = {{cookiecutter.project_slug}},config
 multi_line_output = 3
 default_section = THIRDPARTY
-recursive = true
 skip = venv/
 skip_glob = **/migrations/*.py
 include_trailing_comma = true


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Per #3201, moves config options for isort to be more sensibly labeled and alongside other package configurations, as well as to follow the recommendations in the isort docs. Also removes the "recursive" option as per [this comment](https://github.com/pydanny/cookiecutter-django/issues/3201#issuecomment-878664767) on the issue and [the docs](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html).

Fix #3201