### PR TITLE
Add missing step to getting started locally in docs

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -30,6 +30,7 @@ First things first.
 
 #. Install development requirements: ::
 
+    $ cd <what you have entered as the project_slug at setup stage>
     $ pip install -r requirements/local.txt
     $ git init # A git repo is required for pre-commit to install
     $ pre-commit install


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Just a small change to docs.

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Clears up the installation 
