### PR TITLE
Fix RTD build image to support Python 3.9

### DIFF
--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -3,7 +3,10 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
-python:
+build:
   image: testing
+
+python:
+  version: 3.9
   install:
     - requirements: requirements/local.txt

--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -4,6 +4,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.9
+  image: testing
   install:
     - requirements: requirements/local.txt


### PR DESCRIPTION


<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

* Python 3.9 is technically supported via the testing image.

Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Python 3.9 version is not actually available as a version, only via the image, which is the officially supported place to get Python 3.9. This is probably because most open source projects using RTD uses Python 3.6