### PR TITLE
Update available postgres versions

### DIFF
--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -49,11 +49,10 @@ use_docker:
 postgresql_version:
     Select a PostgreSQL_ version to use. The choices are:
 
-    1. 12.3
-    2. 11.8
-    3. 10.8
-    4. 9.6
-    5. 9.5
+    1. 13.2
+    2. 12.6
+    3. 11.11
+    4. 10.16
 
 js_task_runner:
     Select a JavaScript task runner. The choices are:


### PR DESCRIPTION
The listed versions in the documentation were out of sync with those given when running cookiecutter as recommended in the documentation.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
