### PR TITLE
Updated developing-locally-docker.rst

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -18,7 +18,7 @@ Prerequisites
 
 * Docker; if you don't have it yet, follow the `installation instructions`_;
 * Docker Compose; refer to the official documentation for the `installation guide`_.
-* Pre-commit; refer to the official documentation for the `installation guide`_.
+* Pre-commit; refer to the official documentation for the [pre-commit](https://pre-commit.com/#install).
 
 .. _`installation instructions`: https://docs.docker.com/install/#supported-platforms
 .. _`installation guide`: https://docs.docker.com/compose/install/


### PR DESCRIPTION
changed wrong hyperlink in Prerequisites section

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

third and second hyperlink in Prerequisites section is same. updated third one to right link.
