### PR TITLE
Update heroku create to remove the arguments

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -10,7 +10,7 @@ Run these commands to deploy the project to Heroku:
 
 .. code-block:: bash
 
-    heroku create --buildpack heroku/python 
+    heroku create
 
     heroku addons:create heroku-postgresql:hobby-dev
     # On Windows use double quotes for the time zone, e.g.


### PR DESCRIPTION
With heroku 7.59.0, the following command
.. code-block:: bash

    heroku create --buildback heroku/python
generates this error.

.. code-block:: bash
     ›   Error: Unexpected argument: heroku/python
     ›   See more help with --help
The documentation recommends to just use 
.. code-block:: bash
     heroku create

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
